### PR TITLE
cifsd: Fix smb2.dir.modify failures

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -224,6 +224,14 @@ extern struct list_head global_lock_list;
 #define XATTR_NAME_STREAM	(XATTR_USER_PREFIX STREAM_PREFIX)
 #define XATTR_NAME_STREAM_LEN	(sizeof(XATTR_NAME_STREAM) - 1)
 
+/* FILE ATTRIBUITE XATTR PREFIX */
+#define FILE_ATTRIBUTE_PREFIX   "file.attribute."
+#define FILE_ATTRIBUTE_PREFIX_LEN   (sizeof(FILE_ATTRIBUTE_PREFIX) - 1)
+#define FILE_ATTRIBUTE_LEN      (sizeof(__u32))
+#define XATTR_NAME_FILE_ATTRIBUTE   (XATTR_USER_PREFIX FILE_ATTRIBUTE_PREFIX)
+#define XATTR_NAME_FILE_ATTRIBUTE_LEN \
+	(sizeof(XATTR_USER_PREFIX FILE_ATTRIBUTE_PREFIX) - 1)
+
 /* MAXIMUM KMEM DATA SIZE ORDER */
 #define PAGE_ALLOC_KMEM_ORDER	2
 
@@ -485,6 +493,7 @@ struct cifsd_dir_info {
 struct smb_kstat {
 	struct kstat *kstat;
 	__u64 create_time;
+	__le32 file_attributes;
 };
 
 #define cifsd_debug(fmt, ...)					\
@@ -679,7 +688,10 @@ int smb_get_shortname(struct connection *conn, char *longname,
 char *read_next_entry(struct smb_work *smb_work, struct smb_kstat *smb_kstat,
 		struct smb_dirent *de, char *dpath);
 void *fill_common_info(char **p, struct smb_kstat *smb_kstat);
+/* fill SMB specific fields when smb2 query dir is requested */
 void fill_create_time(struct smb_work *smb_work,
+		struct path *path, struct smb_kstat *smb_kstat);
+void fill_file_attributes(struct smb_work *smb_work,
 		struct path *path, struct smb_kstat *smb_kstat);
 char *convname_updatenextoffset(char *namestr, int len, int size,
 		const struct nls_table *local_nls, int *name_len,

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -4869,9 +4869,51 @@ int smb_filldir(void *__buf, const char *name, int namlen,
 	return 0;
 }
 
+/*
+ * fill_file_attributes() - fill FileAttributes of directory entry in smb_kstat.
+ * if related config is not yes, just fill 0x10(dir) or 0x80(regular file).
+ *
+ * @smb_work: smb work containing share config
+ * @path: path info
+ * @smb_kstat: cifsd kstat wrapper
+ */
+
+void fill_file_attributes(struct smb_work *smb_work,
+	struct path *path, struct smb_kstat *smb_kstat)
+{
+	if (get_attr_store_dos(&smb_work->tcon->share->config.attr)) {
+		char *file_attribute = NULL;
+		int rc;
+		int i;
+
+		rc = smb_find_cont_xattr(path,
+			XATTR_NAME_FILE_ATTRIBUTE,
+			XATTR_NAME_FILE_ATTRIBUTE_LEN, &file_attribute, 1);
+
+		if (rc > 0) {
+			smb_kstat->file_attributes = 0;
+			for (i = 0; i < rc ; i++)
+				smb_kstat->file_attributes +=
+					(__le32)file_attribute[i] << (8*i);
+		}
+
+		else
+			cifsd_debug("fail to fill file attributes.\n");
+
+		kvfree(file_attribute);
+	}
+
+	else {
+		if (S_ISDIR(smb_kstat->kstat->mode))
+			smb_kstat->file_attributes = ATTR_DIRECTORY;
+		else
+			smb_kstat->file_attributes = ATTR_ARCHIVE;
+	}
+}
+
 /**
  * fill_create_time() - fill create time of directory entry in smb_kstat
- * if related config is not set, create time is same with change time
+ * if related config is not yes, create time is same with change time
  *
  * @smb_work: smb work containing share config
  * @path: path info
@@ -4948,6 +4990,7 @@ char *read_next_entry(struct smb_work *smb_work, struct smb_kstat *smb_kstat,
 
 	generic_fillattr(path.dentry->d_inode, smb_kstat->kstat);
 	fill_create_time(smb_work, &path, smb_kstat);
+	fill_file_attributes(smb_work, &path, smb_kstat);
 	memcpy(name, de->name, de->namelen);
 	name[de->namelen] = '\0';
 	path_put(&path);
@@ -4972,8 +5015,7 @@ void *fill_common_info(char **p, struct smb_kstat *smb_kstat)
 			cifs_UnixTimeToNT(smb_kstat->kstat->ctime));
 	info->EndOfFile = cpu_to_le64(smb_kstat->kstat->size);
 	info->AllocationSize = cpu_to_le64(smb_kstat->kstat->blocks << 9);
-	info->ExtFileAttributes = S_ISDIR(smb_kstat->kstat->mode) ?
-		ATTR_DIRECTORY : ATTR_NORMAL;
+	info->ExtFileAttributes = cpu_to_le32(smb_kstat->file_attributes);
 
 	return info;
 }


### PR DESCRIPTION
1. add logics to store FileAttributes of a file in xattr
for file creation and set info query, and to find the value
from xattr for file open and get info query when store dos
attributes is yes. By doing it, the FileAttributes field
in res buffer has an appropirate value.

2. delete dead code in smb2_get_dos_mode.

3. make directory re-opened for SMB2_RESTART_SCANS flag to avoid
some directory entries not read.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>