### PR TITLE
cifsd: fix smb2.dir.modify failures and modify the way to get xattr values

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -224,6 +224,14 @@ extern struct list_head global_lock_list;
 #define XATTR_NAME_STREAM	(XATTR_USER_PREFIX STREAM_PREFIX)
 #define XATTR_NAME_STREAM_LEN	(sizeof(XATTR_NAME_STREAM) - 1)
 
+/* FILE ATTRIBUITE XATTR PREFIX */
+#define FILE_ATTRIBUTE_PREFIX   "file.attribute."
+#define FILE_ATTRIBUTE_PREFIX_LEN   (sizeof(FILE_ATTRIBUTE_PREFIX) - 1)
+#define FILE_ATTRIBUTE_LEN      (sizeof(__u32))
+#define XATTR_NAME_FILE_ATTRIBUTE   (XATTR_USER_PREFIX FILE_ATTRIBUTE_PREFIX)
+#define XATTR_NAME_FILE_ATTRIBUTE_LEN \
+	(sizeof(XATTR_USER_PREFIX FILE_ATTRIBUTE_PREFIX) - 1)
+
 /* MAXIMUM KMEM DATA SIZE ORDER */
 #define PAGE_ALLOC_KMEM_ORDER	2
 
@@ -495,6 +503,7 @@ struct cifsd_dir_info {
 struct smb_kstat {
 	struct kstat *kstat;
 	__u64 create_time;
+	__le32 file_attributes;
 };
 
 #define cifsd_debug(fmt, ...)					\
@@ -694,7 +703,10 @@ int smb_get_shortname(struct connection *conn, char *longname,
 char *read_next_entry(struct smb_work *smb_work, struct smb_kstat *smb_kstat,
 		struct smb_dirent *de, char *dpath);
 void *fill_common_info(char **p, struct smb_kstat *smb_kstat);
+/* fill SMB specific fields when smb2 query dir is requested */
 void fill_create_time(struct smb_work *smb_work,
+		struct path *path, struct smb_kstat *smb_kstat);
+void fill_file_attributes(struct smb_work *smb_work,
 		struct path *path, struct smb_kstat *smb_kstat);
 char *convname_updatenextoffset(char *namestr, int len, int size,
 		const struct nls_table *local_nls, int *name_len,

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -4896,12 +4896,8 @@ void fill_create_time(struct smb_work *smb_work,
 			XATTR_NAME_CREATION_TIME,
 			XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 
-		if (xattr_len > 0) {
-			smb_kstat->create_time = 0;
-			for (i = 0; i < xattr_len ; i++)
-				smb_kstat->create_time +=
-				((__u64)create_time[i]) << (8*i);
-		}
+		if (xattr_len > 0)
+			smb_kstat->create_time = *((u64 *)create_time);
 
 		kvfree(create_time);
 	}

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -855,9 +855,9 @@ void smb2_send_interim_resp(struct smb_work *smb_work)
  *
  * Return:      converted dos mode
  */
-int smb2_get_dos_mode(struct kstat *stat, int attribute)
+__le32 smb2_get_dos_mode(struct kstat *stat, __le32 attribute)
 {
-	int attr = 0;
+	__le32 attr = 0;
 
 	attr = (attribute & 0x00005137) | ATTR_ARCHIVE;
 
@@ -865,9 +865,6 @@ int smb2_get_dos_mode(struct kstat *stat, int attribute)
 		attr = ATTR_DIRECTORY;
 	else
 		attr &= ~(ATTR_DIRECTORY);
-
-	if (!attr)
-		attr = ATTR_NORMAL;
 
 	return attr;
 }
@@ -2419,7 +2416,8 @@ reconnect:
 	fp->daccess = req->DesiredAccess;
 	fp->saccess = req->ShareAccess;
 	fp->coption = req->CreateOptions;
-	fp->fattr = req->FileAttributes;
+	fp->fattr = cpu_to_le32(smb2_get_dos_mode(&stat,
+		le32_to_cpu(req->FileAttributes)));
 	INIT_LIST_HEAD(&fp->lock_list);
 
 	if (islink) {
@@ -2575,6 +2573,7 @@ reconnect:
 			rc = smb_find_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
+
 			if (rc > 0)
 				fp->create_time = *((__u64 *)create_time);
 
@@ -2593,6 +2592,36 @@ reconnect:
 		}
 	}
 
+	if (file_present) {
+		/* get FileAttributes from XATTR_NAME_FILE_ATTRIBUTE */
+		if (get_attr_store_dos(&smb_work->tcon->share->config.attr)) {
+			char *file_attribute = NULL;
+
+			rc = smb_find_cont_xattr(&path,
+				 XATTR_NAME_FILE_ATTRIBUTE,
+				 XATTR_NAME_FILE_ATTRIBUTE_LEN,
+				 &file_attribute, 1);
+
+			if (rc > 0)
+				fp->fattr = *((__le32 *)file_attribute);
+
+			kvfree(file_attribute);
+			rc = 0;
+		}
+	} else {
+		/* set XATTR_NAME_FILE_ATTRIBUTE with req->FileAttributes */
+		if (get_attr_store_dos(&smb_work->tcon->share->config.attr)) {
+			rc = smb_store_cont_xattr(&path,
+				XATTR_NAME_FILE_ATTRIBUTE,
+				(void *)&fp->fattr, FILE_ATTRIBUTE_LEN);
+
+			if (rc)
+				cifsd_debug("failed to store file attribute in EA\n");
+
+			rc = 0;
+		}
+	}
+
 	rsp->CreationTime = cpu_to_le64(fp->create_time);
 	rsp->LastAccessTime = cpu_to_le64(cifs_UnixTimeToNT(stat.atime));
 	rsp->LastWriteTime = cpu_to_le64(cifs_UnixTimeToNT(stat.mtime));
@@ -2600,8 +2629,7 @@ reconnect:
 	rsp->AllocationSize = S_ISDIR(stat.mode) ? 0 :
 			cpu_to_le64(stat.blocks << 9);
 	rsp->EndofFile = S_ISDIR(stat.mode) ? 0 : cpu_to_le64(stat.size);
-	rsp->FileAttributes = cpu_to_le32(smb2_get_dos_mode(&stat,
-		le32_to_cpu(req->FileAttributes)));
+	rsp->FileAttributes = cpu_to_le32(fp->fattr);
 
 	rsp->Reserved2 = 0;
 
@@ -3057,7 +3085,7 @@ int smb2_query_dir(struct smb_work *smb_work)
 		dir_fp->dirent_offset = 0;
 	}
 
-	if (srch_flag & SMB2_REOPEN) {
+	if ((srch_flag & SMB2_REOPEN) || (srch_flag & SMB2_RESTART_SCANS)) {
 		cifsd_debug("Reopen the directory\n");
 		filp_close(dir_fp->filp, NULL);
 		dir_fp->filp = filp_open(dirpath, O_RDONLY, 0666);
@@ -3066,13 +3094,6 @@ int smb2_query_dir(struct smb_work *smb_work)
 			rc = -EINVAL;
 			goto err_out;
 		}
-		dir_fp->readdir_data.used = 0;
-		dir_fp->dirent_offset = 0;
-	}
-
-	if (srch_flag & SMB2_RESTART_SCANS) {
-		cifsd_debug("SMB2 RESTART SCANS\n");
-		generic_file_llseek(dir_fp->filp, 0, SEEK_SET);
 		dir_fp->readdir_data.used = 0;
 		dir_fp->dirent_offset = 0;
 	}
@@ -3828,8 +3849,7 @@ int smb2_info_file(struct smb_work *smb_work)
 			cpu_to_le64(cifs_UnixTimeToNT(stat.mtime));
 		basic_info->ChangeTime =
 			cpu_to_le64(cifs_UnixTimeToNT(stat.ctime));
-		basic_info->Attributes = S_ISDIR(stat.mode) ?
-					ATTR_DIRECTORY : ATTR_NORMAL;
+		basic_info->Attributes = cpu_to_le32(fp->fattr);
 		basic_info->Pad1 = 0;
 		rsp->OutputBufferLength =
 			cpu_to_le32(offsetof(struct smb2_file_all_info,
@@ -4829,6 +4849,24 @@ int smb2_set_info_file(struct smb_work *smb_work)
 			attrs.ia_mtime = cifs_NTtimeToUnix(
 					le64_to_cpu(file_info->LastWriteTime));
 			attrs.ia_valid |= (ATTR_MTIME | ATTR_MTIME_SET);
+		}
+
+		if (le32_to_cpu(file_info->Attributes)) {
+			unsigned long *config_attr;
+
+			config_attr = &smb_work->tcon->share->config.attr;
+			fp->fattr = file_info->Attributes;
+			if (get_attr_store_dos(config_attr)) {
+				rc = smb_store_cont_xattr(&fp->filp->f_path,
+						XATTR_NAME_FILE_ATTRIBUTE,
+						(void *)&fp->fattr,
+						FILE_ATTRIBUTE_LEN);
+
+				if (rc)
+					cifsd_debug("failed to store file attribute in EA\n");
+
+				rc = 0;
+			}
 		}
 
 		if (attrs.ia_valid) {

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2575,12 +2575,9 @@ reconnect:
 			rc = smb_find_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
-			if (rc > 0) {
-				fp->create_time = 0;
-				for (i = 0; i < rc ; i++)
-					fp->create_time +=
-					(__u64)create_time[i] << (8*i);
-			}
+			if (rc > 0)
+				fp->create_time = *((__u64 *)create_time);
+
 			kvfree(create_time);
 			rc = 0;
 		}


### PR DESCRIPTION
cifsd: fix smb2.dir.modify failures and modify the way to get xattr values