### PR TITLE
cifsd: fix some smb2.setinfo failures

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -628,6 +628,7 @@ extern int check_invalid_char(char *filename);
 extern int parse_stream_name(char *filename, char **stream_name, int *s_type);
 extern int construct_xattr_stream_name(char *stream_name,
 	char **xattr_stream_name);
+extern unsigned short get_logical_sector_size(struct inode *inode);
 
 /* smb vfs functions */
 int smb_vfs_create(const char *name, umode_t mode);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4971,6 +4971,7 @@ out:
  * @smb_work:	smb work containing set info command buffer
  *
  * Return:	0 on success, otherwise error
+ * TODO: need to implement an error handling for STATUS_INFO_LENGTH_MISMATCH
  */
 int smb2_set_info_file(struct smb_work *smb_work)
 {
@@ -5060,6 +5061,13 @@ int smb2_set_info_file(struct smb_work *smb_work)
 
 		if (le32_to_cpu(file_info->Attributes)) {
 			unsigned long *config_attr;
+
+			if (!S_ISDIR(file_inode(filp)->i_mode)
+				&& file_info->Attributes == ATTR_DIRECTORY) {
+				cifsd_debug("can't change a file to a directory\n");
+				smb2_set_err_rsp(smb_work);
+				return -EINVAL;
+			}
 
 			config_attr = &smb_work->tcon->share->config.attr;
 			fp->fattr = file_info->Attributes;
@@ -5221,6 +5229,28 @@ next:
 		req = (struct smb2_set_info_req *)smb_work->buf;
 		rc = smb2_set_ea((struct smb2_ea_info *)(req->Buffer),
 			&filp->f_path);
+		break;
+	}
+	case FILE_POSITION_INFORMATION:
+	{
+		struct smb2_file_pos_info *file_info;
+		loff_t current_byte_offset;
+		unsigned short sector_size;
+
+		file_info = (struct smb2_file_pos_info *)req->Buffer;
+		current_byte_offset = le64_to_cpu(file_info->CurrentByteOffset);
+		sector_size = get_logical_sector_size(inode);
+
+		if (current_byte_offset < 0 ||
+			(fp->coption == FILE_NO_INTERMEDIATE_BUFFERING_LE &&
+			current_byte_offset & (sector_size-1))) {
+			cifsd_err("CurrentByteOffset is not valid : %llu\n",
+				current_byte_offset);
+			return -EINVAL;
+		}
+
+		filp->f_pos = current_byte_offset;
+
 		break;
 	}
 	default:

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -5079,7 +5079,6 @@ int smb2_set_info_file(struct smb_work *smb_work)
 			if (!S_ISDIR(file_inode(filp)->i_mode)
 				&& file_info->Attributes == ATTR_DIRECTORY) {
 				cifsd_err("can't change a file to a directory\n");
-				smb2_set_err_rsp(smb_work);
 				return -EINVAL;
 			}
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -5078,7 +5078,7 @@ int smb2_set_info_file(struct smb_work *smb_work)
 
 			if (!S_ISDIR(file_inode(filp)->i_mode)
 				&& file_info->Attributes == ATTR_DIRECTORY) {
-				cifsd_debug("can't change a file to a directory\n");
+				cifsd_err("can't change a file to a directory\n");
 				smb2_set_err_rsp(smb_work);
 				return -EINVAL;
 			}

--- a/vfs.c
+++ b/vfs.c
@@ -29,6 +29,8 @@
 #include <linux/xattr.h>
 #endif
 #include <linux/falloc.h>
+#include <linux/genhd.h>
+#include <linux/blkdev.h>
 
 #include "export.h"
 #include "glob.h"
@@ -1246,4 +1248,24 @@ int smb_vfs_alloc_size(struct file *filp, loff_t len)
 int smb_vfs_remove_xattr(struct file *filp, char *field_name)
 {
 	return vfs_removexattr(filp->f_path.dentry, field_name);
+}
+
+/*
+ * get_logical_sector_size() - get logical sector size from inode
+ * @inode: inode
+ *
+ * Return: logical sector size
+ */
+unsigned short get_logical_sector_size(struct inode *inode)
+{
+	struct request_queue *q;
+	int ret_val;
+
+	ret_val = 512;
+	q = inode->i_sb->s_bdev->bd_disk->queue;
+
+	if (q && q->limits.logical_block_size)
+		ret_val = q->limits.logical_block_size;
+
+	return ret_val;
 }


### PR DESCRIPTION
1. make setinfo not to allow to change non-directory file's attributes
into ATTR_DIRECTORY.

2. implement set_info FILE_POSITION_INFORMATION case.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>