### PR TITLE
cifsd: fix some smb2.setinfo failures

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -627,6 +627,7 @@ extern int check_invalid_char(char *filename);
 extern int parse_stream_name(char *filename, char **stream_name, int *s_type);
 extern int construct_xattr_stream_name(char *stream_name,
 	char **xattr_stream_name);
+extern unsigned short get_logical_sector_size(struct inode *inode);
 
 /* smb vfs functions */
 int smb_vfs_create(const char *name, umode_t mode);

--- a/vfs.c
+++ b/vfs.c
@@ -29,6 +29,8 @@
 #include <linux/xattr.h>
 #endif
 #include <linux/falloc.h>
+#include <linux/genhd.h>
+#include <linux/blkdev.h>
 
 #include "export.h"
 #include "glob.h"
@@ -1283,4 +1285,24 @@ out:
 		cifsd_debug("failed to delete, err %d\n", err);
 
 	return err;
+}
+
+/*
+ * get_logical_sector_size() - get logical sector size from inode
+ * @inode: inode
+ *
+ * Return: logical sector size
+ */
+unsigned short get_logical_sector_size(struct inode *inode)
+{
+	struct request_queue *q;
+	int ret_val;
+
+	ret_val = 512;
+	q = inode->i_sb->s_bdev->bd_disk->queue;
+
+	if (q && q->limits.logical_block_size)
+		ret_val = q->limits.logical_block_size;
+
+	return ret_val;
 }


### PR DESCRIPTION
1. make setinfo not to allow to change non-directory file's attributes
into ATTR_DIRECTORY.

2. implement set_info FILE_POSITION_INFORMATION case.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>