### PR TITLE
cifsd: fix nlink and delete_pending

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -1283,7 +1283,6 @@ void mfp_init(struct cifsd_mfile *mfp, struct inode *inode)
 {
 	mfp->m_inode = inode;
 	atomic_set(&mfp->m_count, 0);
-	mfp->m_nlink = 0;
 	mfp->m_flags = 0;
 	INIT_LIST_HEAD(&mfp->m_fp_list);
 	insert_mfp_hash(mfp);

--- a/fh.h
+++ b/fh.h
@@ -103,7 +103,6 @@ struct stream {
 struct cifsd_mfile {
 	atomic_t m_count;
 	struct inode *m_inode;
-	unsigned int m_nlink;
 	unsigned int m_flags;
 	struct hlist_node m_hash;
 	struct list_head m_fp_list;


### PR DESCRIPTION
fix some FileInfoClass to make NumberOfLinks and DeletePending
give valid values when get_info is requested.

when FileDispositionInformation's DeletePending is 0,
clear S_DEL_ON_CLS bit of mfp->m_flags.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>
Signed-off-by: Namjae Jeon <namjae.jeon@protocolfreedom.org>