### PR TITLE
cifsd: hack to give valid ctime value

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -5039,6 +5039,7 @@ int smb2_set_info_file(struct smb_work *smb_work)
 	{
 		struct smb2_file_all_info *file_info;
 		struct iattr attrs;
+		struct iattr temp_attrs;
 
 		if (!(fp->daccess & (FILE_WRITE_ATTRIBUTES_LE |
 			FILE_GENERIC_WRITE_LE | FILE_MAXIMAL_ACCESS_LE |
@@ -5077,10 +5078,11 @@ int smb2_set_info_file(struct smb_work *smb_work)
 		}
 
 		if (le64_to_cpu(file_info->ChangeTime)) {
-			attrs.ia_ctime = cifs_NTtimeToUnix(
-					le64_to_cpu(file_info->ChangeTime));
+			temp_attrs.ia_ctime = attrs.ia_ctime =
+			cifs_NTtimeToUnix(le64_to_cpu(file_info->ChangeTime));
 			attrs.ia_valid |= ATTR_CTIME;
-		}
+		} else
+			temp_attrs.ia_ctime = inode->i_ctime;
 
 		if (le64_to_cpu(file_info->LastWriteTime)) {
 			attrs.ia_mtime = cifs_NTtimeToUnix(
@@ -5111,6 +5113,13 @@ int smb2_set_info_file(struct smb_work *smb_work)
 				rc = 0;
 			}
 		}
+
+		/*
+		 * HACK : set ctime here to avoid ctime changed
+		 * when file_info->ChangeTime is zero.
+		 */
+		 attrs.ia_ctime = temp_attrs.ia_ctime;
+		 attrs.ia_valid |= ATTR_CTIME;
 
 		if (attrs.ia_valid) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 37)


### PR DESCRIPTION
make ctime value not to be changed by storing xattr value.
by doing so, ctime is not changed when file_info->CtreationTime
is zero.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>