### PR TITLE
cifsd: fix torture setinfo failures

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -426,7 +426,7 @@ int close_id(struct cifsd_sess *sess, uint64_t id, uint64_t p_id)
 
 	if (fp->is_stream && (mfp->m_flags & S_DEL_ON_CLS_STREAM)) {
 		mfp->m_flags &= ~S_DEL_ON_CLS_STREAM;
-		err = smb_vfs_remove_xattr(filp, fp->stream.name);
+		err = smb_vfs_remove_xattr(&(filp->f_path), fp->stream.name);
 		if (err)
 			cifsd_err("remove xattr failed : %s\n",
 				fp->stream.name);

--- a/glob.h
+++ b/glob.h
@@ -674,7 +674,7 @@ int smb_vfs_readdir(struct file *file, filldir_t filler,
 int smb_vfs_alloc_size(struct file *filp, loff_t len);
 int smb_vfs_truncate_xattr(struct dentry *dentry);
 int smb_vfs_truncate_stream_xattr(struct dentry *dentry);
-int smb_vfs_remove_xattr(struct file *filp, char *field_name);
+int smb_vfs_remove_xattr(struct path *path, char *field_name);
 int smb_vfs_unlink(struct dentry *dir, struct dentry *dentry);
 unsigned short get_logical_sector_size(struct inode *inode);
 void get_smb2_sector_size(struct inode *inode,

--- a/vfs.c
+++ b/vfs.c
@@ -988,6 +988,7 @@ ssize_t smb_vfs_listxattr(struct dentry *dentry, char **list, int size)
  * @dentry:	dentry of file for getting xattrs
  * @xattr_name:	name of xattr name to query
  * @xattr_buf:	destination buffer xattr value
+ * @flags: if 0, return stored xattr's length only
  *
  * Return:	read xattr value length on success, otherwise error
  */
@@ -1248,9 +1249,9 @@ int smb_vfs_alloc_size(struct file *filp, loff_t len)
 	return vfs_fallocate(filp, FALLOC_FL_KEEP_SIZE, 0, len);
 }
 
-int smb_vfs_remove_xattr(struct file *filp, char *field_name)
+int smb_vfs_remove_xattr(struct path *path, char *field_name)
 {
-	return vfs_removexattr(filp->f_path.dentry, field_name);
+	return vfs_removexattr(path->dentry, field_name);
 }
 
 int smb_vfs_unlink(struct dentry *dir, struct dentry *dentry)


### PR DESCRIPTION
fix next_offset to get valid value.

fix smb2_set_ea function to delete xattr when EaValueLength is zero.
When setting EA information, if EaValueLength is zero,
then the given EaName and its current value are deleted
from the given file.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>