### PR TITLE
cifsd: implement setinfo FileAllocationInformation

### DIFF
--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -1221,8 +1221,7 @@ struct smb2_file_ea_info {
 } __packed;
 
 struct smb2_file_alloc_info {
-	__le32 Attributes;
-	__le32 ReparseTag;
+	__le64 AllocationSize;
 } __packed;
 
 struct smb2_file_disposition_info {


### PR DESCRIPTION
implement setinfo FileAllocationInformation
which fallocates or truncates opened file's allocated size
based on current i_blocks and AllocationSize requested.

because FileAllocationInformation is only for setinfo,
getinfo FileAllocationInformation is deleted.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>