### PR TITLE
cifsd: fix some getinfo torture failures

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4577,6 +4577,33 @@ int smb2_get_info_filesystem(struct smb_work *smb_work)
 			fs_infoclass_size = FS_SECTOR_SIZE_INFORMATION_SIZE;
 			break;
 		}
+	case FS_CONTROL_INFORMATION:
+		{
+			/*
+			 * TODO : The current implementation is based on
+			 * test result with win7(NTFS) server. It's need to
+			 * modify this to get valid Quota values
+			 * from Linux kernel
+			 */
+
+			 struct smb2_fs_control_info *fs_control_info;
+
+			 fs_control_info =
+				(struct smb2_fs_control_info *)(rsp->Buffer);
+			 fs_control_info->FreeSpaceStartFiltering = 0;
+			 fs_control_info->FreeSpaceThreshold = 0;
+			 fs_control_info->FreeSpaceStopFiltering = 0;
+			 fs_control_info->DefaultQuotaThreshold =
+				0xFFFFFFFFFFFFFFFF;
+			 fs_control_info->DefaultQuotaLimit =
+				0xFFFFFFFFFFFFFFFF;
+			 fs_control_info->Padding = 0;
+			 rsp->OutputBufferLength = cpu_to_le32(48);
+			 inc_rfc1001_len(rsp_org, 48);
+			 fs_infoclass_size = FS_CONTROL_INFORMATION_SIZE;
+
+			 break;
+		}
 	default:
 		rsp->hdr.Status = NT_STATUS_NOT_SUPPORTED;
 		path_put(&path);

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -955,11 +955,11 @@ struct smb2_set_info_rsp {
 #define FILE_FULL_EA_INFORMATION_SIZE         15
 #define FILE_MODE_INFORMATION_SIZE            4
 #define FILE_ALIGNMENT_INFORMATION_SIZE       4
-#define FILE_ALL_INFORMATION_SIZE             100
+#define FILE_ALL_INFORMATION_SIZE             104
 #define FILE_ALLOCATION_INFORMATION_SIZE      19
 #define FILE_END_OF_FILE_INFORMATION_SIZE     20
 #define FILE_ALTERNATE_NAME_INFORMATION_SIZE  8
-#define FILE_STREAM_INFORMATION_SIZE          24
+#define FILE_STREAM_INFORMATION_SIZE          32
 #define FILE_PIPE_INFORMATION_SIZE            23
 #define FILE_PIPE_LOCAL_INFORMATION_SIZE      24
 #define FILE_PIPE_REMOTE_INFORMATION_SIZE     25
@@ -983,7 +983,7 @@ struct smb2_set_info_rsp {
 #define FS_FULL_SIZE_INFORMATION_SIZE  32
 #define FS_SECTOR_SIZE_INFORMATION_SIZE 28
 #define FS_OBJECT_ID_INFORMATION_SIZE 64
-
+#define FS_CONTROL_INFORMATION_SIZE 48
 
 /* FS_ATTRIBUTE_File_System_Name */
 #define FS_TYPE_SUPPORT_SIZE   44
@@ -1069,6 +1069,16 @@ struct smb3_fs_ss_info {
 	__le32 ByteOffsetForPartitionAlignment;
 } __packed;
 
+/* File System Control Information */
+struct smb2_fs_control_info {
+	__le64 FreeSpaceStartFiltering;
+	__le64 FreeSpaceThreshold;
+	__le64 FreeSpaceStopFiltering;
+	__le64 DefaultQuotaThreshold;
+	__le64 DefaultQuotaLimit;
+	__le32 FileSystemControlFlags;
+	__le32 Padding;
+} __packed;
 
 /* partial list of QUERY INFO levels */
 #define FILE_DIRECTORY_INFORMATION	1


### PR DESCRIPTION
Add get_info FS_CONTROL_INFORMATION.

Modify some file_info_classes' sizes based on a smb2 torture TC and
Windows 7. it needs to consider variable-sized field's minimum size.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>