### PR TITLE
cifsd: implement smb2_notify command

### DIFF
--- a/export.h
+++ b/export.h
@@ -122,6 +122,7 @@ struct cifsd_sess {
 	__u8 Preauth_HashValue[64];
 	struct cifsd_pipe *pipe_desc[MAX_PIPE];
 	wait_queue_head_t pipe_q;
+	wait_queue_head_t notify_q;
 	int ev_state;
 };
 

--- a/glob.h
+++ b/glob.h
@@ -90,6 +90,8 @@ extern bool global_signing;
 
 extern struct list_head global_lock_list;
 
+extern struct smb2_inotify_res_info *inotify_res;
+
 /* cifsd's Specific ERRNO */
 #define ESHARE 50000
 
@@ -535,6 +537,25 @@ struct cifsd_pid_info {
 	__u32 cifsd_pid;
 };
 
+struct smb2_inotify_req_info {
+	__le16 watch_tree_flag;
+	__le32 CompletionFilter;
+	__u32 path_len;
+	char dir_path[];
+};
+
+struct FileNotifyInformation {
+	__le32 NextEntryOffset;
+	__le32 Action;
+	__le32 FileNameLength;
+	__le16 FileName[];
+};
+
+struct smb2_inotify_res_info {
+	__u32 output_buffer_length;
+	struct FileNotifyInformation file_notify_info[];
+};
+
 #define cifsd_debug(fmt, ...)					\
 	do {							\
 		if (cifsd_debug_enable)				\
@@ -749,6 +770,10 @@ void cifsd_net_exit(void);
 int cifsd_sendmsg(struct cifsd_sess *sess, unsigned int etype,
 		int pipe_type, unsigned int data_size,
 		unsigned char *data, unsigned int out_buflen);
+int cifsd_sendmsg_notify(struct cifsd_sess *sess,
+		unsigned int data_size,
+		struct smb2_inotify_req_info *inotify_req_info,
+		char *path);
 int cifsd_kthread_stop_status(int etype);
 
 /* asn1 functions */

--- a/netlink.h
+++ b/netlink.h
@@ -42,6 +42,7 @@ enum cifsd_uevent_e {
 	CIFSD_UEVENT_IOCTL_PIPE_RSP,
 	CIFSD_UEVENT_LANMAN_PIPE_RSP,
 	CIFSD_UEVENT_EXIT_CONNECTION,
+	CIFSD_UEVENT_INOTIFY_RESPONSE,
 
 	/* up events: kernel space to userspace */
 	CIFSD_KEVENT_CREATE_PIPE     = 100,
@@ -51,6 +52,7 @@ enum cifsd_uevent_e {
 	CIFSD_KEVENT_LANMAN_PIPE,
 	CIFSD_KEVENT_DESTROY_PIPE,
 	CFISD_KEVENT_USER_DAEMON_EXIST,
+	CIFSD_KEVENT_INOTIFY_REQUEST,
 };
 
 struct cifsd_uevent {
@@ -59,6 +61,8 @@ struct cifsd_uevent {
 	__u64		conn_handle;
 	unsigned int	buflen;
 	unsigned int	pipe_type;
+	char codepage[CIFSD_CODEPAGE_LEN];
+
 	union {
 		/* messages u -> k */
 		unsigned int	nt_status;

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -800,13 +800,6 @@ struct smb2_notify_rsp {
 #define FILE_ACTION_MODIFIED_STREAM	0x00000008
 #define FILE_ACTION_REMOVED_BY_DELETE	0x00000009
 
-struct FileNotifyInformation {
-	__le32 NextEntryOffset;
-	__le32 Action;
-	__le32 FileNameLength;
-	char FileName[0];
-} __packed;
-
 #define SMB2_LOCKFLAG_SHARED		0x0001
 #define SMB2_LOCKFLAG_EXCLUSIVE		0x0002
 #define SMB2_LOCKFLAG_UNLOCK		0x0004


### PR DESCRIPTION
This patch is to add a smb2_notify implementation into cifsd.

When a smb2 notify request is received from a client,
an inotify-request is sent to user-space.
when an event, which matches with completion filter
in the notify request packet, occurs, user daemon send
a netlink event to kernel-space with notify response information.

Then kernel send a notify response packet to the client
with the information.

Please check cifsd-tools' pull-request also.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>