### PR TITLE
cifsd: support multiple sessions

### DIFF
--- a/export.h
+++ b/export.h
@@ -121,6 +121,7 @@ struct cifsd_sess {
 	int state;
 	__u8 Preauth_HashValue[64];
 	struct cifsd_pipe *pipe_desc[MAX_PIPE];
+	struct smb2_inotify_res_info *inotify_res;
 	wait_queue_head_t pipe_q;
 	wait_queue_head_t notify_q;
 	int ev_state;

--- a/glob.h
+++ b/glob.h
@@ -90,8 +90,6 @@ extern bool global_signing;
 
 extern struct list_head global_lock_list;
 
-extern struct smb2_inotify_res_info *inotify_res;
-
 /* cifsd's Specific ERRNO */
 #define ESHARE 50000
 

--- a/netlink.c
+++ b/netlink.c
@@ -333,16 +333,18 @@ static int cifsd_notify_rsp(struct nlmsghdr *nlh)
 	cifsd_debug("noti_info_res_buf->file_notify_info[0].Action : %d\n",
 		noti_info_res_buf->file_notify_info[0].Action);
 
-	inotify_res = kmalloc(inotify_res_size + file_noti_size + NAME_MAX,
+	sess->inotify_res = kmalloc(inotify_res_size
+		+ file_noti_size + NAME_MAX,
 		GFP_KERNEL);
-	memcpy(inotify_res, noti_info_res_buf,
+	memcpy(sess->inotify_res, noti_info_res_buf,
 		inotify_res_size + file_noti_size + NAME_MAX);
 
-	if (!inotify_res)
+	if (!sess->inotify_res)
 		return -ENOMEM;
 
 	sess->ev_state = NETLINK_REQ_RECV;
 	wake_up_interruptible(&sess->notify_q);
+
 	return 0;
 }
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -88,9 +88,6 @@ struct fs_type_info fs_type[] = {
 	{ "CGROUP",	0x27e0eb},
 	};
 
-/* global variables for notify command */
-struct smb2_inotify_res_info *inotify_res;
-
 /**
  * check_session_id() - check for valid session id in smb header
  * @conn:	TCP server instance of connection
@@ -6940,14 +6937,15 @@ int smb2_notify(struct smb_work *smb_work)
 {
 	struct smb2_notify_req *req;
 	struct smb2_notify_rsp *rsp, *rsp_org;
-	struct cifsd_file *fp;
+	struct cifsd_file *fp, *prev_fp;
+	struct notification *notify_req;
+	struct notification *request;
+	struct smb_work *work;
 	int rc = 0;
 	char *path;
 	char *path_buf = NULL;
 	int path_len = 0;
 	struct smb2_inotify_req_info inotify_req_info;
-
-	smb2_send_interim_resp(smb_work);
 
 	req = (struct smb2_notify_req *)smb_work->buf;
 	rsp = (struct smb2_notify_rsp *)smb_work->rsp_buf;
@@ -6962,15 +6960,13 @@ int smb2_notify(struct smb_work *smb_work)
 
 	if (req->StructureSize != 32) {
 		cifsd_err("malformed packet\n");
-		smb_work->send_no_response = 1;
-		goto out;
+		goto out1;
 	}
 
 	if (smb_work->next_smb2_rcv_hdr_off &&
 			le32_to_cpu(req->hdr.NextCommand)) {
 		rsp->hdr.Status = NT_STATUS_INTERNAL_ERROR;
-		smb2_set_err_rsp(smb_work);
-		goto out;
+		goto out2;
 	}
 
 	fp = get_fp(smb_work, le64_to_cpu(req->VolatileFileId),
@@ -6978,14 +6974,30 @@ int smb2_notify(struct smb_work *smb_work)
 	if (!fp) {
 		rsp->hdr.Status = NT_STATUS_FILE_CLOSED;
 		rc = -ENOENT;
-		goto out;
+		goto out2;
 	}
 
 	path_buf = kmalloc(PATH_MAX, GFP_KERNEL);
 	if (!path_buf) {
 		rsp->hdr.Status = NT_STATUS_NO_MEMORY;
 		rc = -ENOENT;
-		goto out;
+		goto out2;
+	}
+
+	notify_req = kmalloc(sizeof(struct notification), GFP_KERNEL);
+	if (!notify_req) {
+		rsp->hdr.Status = NT_STATUS_NO_MEMORY;
+		rc = -ENOENT;
+		goto out2;
+	}
+	notify_req->work = smb_work;
+
+	hash_for_each_possible(smb_work->sess->notify_table, prev_fp,
+		notify_node, (unsigned long)FP_INODE(fp)) {
+		if (FP_INODE(fp) == FP_INODE(prev_fp)) {
+			list_add_tail(&notify_req->queuelist, &prev_fp->queue);
+			goto out1;
+		}
 	}
 
 	path = d_path(&(fp->filp->f_path), path_buf, PATH_MAX);
@@ -6993,30 +7005,59 @@ int smb2_notify(struct smb_work *smb_work)
 		cifsd_err("Failed to get complete dir path\n");
 		rsp->hdr.Status = NT_STATUS_INVALID_PARAMETER;
 		rc = PTR_ERR(path);
-		goto out;
+		kfree(path_buf);
+		goto out2;
 	}
 	path_len = strlen(path);
 
-	/* TODO : implement recursive monitoring */
-	inotify_req_info.watch_tree_flag = 0;
-	inotify_req_info.CompletionFilter = req->CompletionFileter;
-	inotify_req_info.path_len = path_len;
+	INIT_LIST_HEAD(&fp->queue);
+	list_add_tail(&notify_req->queuelist, &fp->queue);
 
-	rc = cifsd_sendmsg_notify(smb_work->sess,
-		sizeof(inotify_req_info)+path_len,
-		&inotify_req_info, path);
+	while (!list_empty(&fp->queue)) {
+		request = list_first_entry_or_null(&fp->queue,
+			struct notification, queuelist);
+		if (!request)
+			continue;
+		list_del_init(&request->queuelist);
 
-	rsp->hdr.Status = NT_STATUS_OK;
-	rsp->StructureSize = cpu_to_le16(9);
-	rsp->OutputBufferOffset = cpu_to_le16(72);
-	rsp->OutputBufferLength = inotify_res->output_buffer_length;
+		work = request->work;
+		smb2_send_interim_resp(work);
+		req = (struct smb2_notify_req *)work->buf;
+		rsp = (struct smb2_notify_rsp *)work->rsp_buf;
+		rsp_org = rsp;
 
-	memcpy(rsp->Buffer, &(inotify_res->file_notify_info[0]),
-		sizeof(struct FileNotifyInformation) + NAME_MAX);
-	inc_rfc1001_len(rsp_org, 8 + rsp->OutputBufferLength);
+		/* TODO : implement recursive monitoring */
+		inotify_req_info.watch_tree_flag = 0;
+		inotify_req_info.CompletionFilter = req->CompletionFileter;
+		inotify_req_info.path_len = path_len;
 
-out:
-	kfree(path_buf);
+		rc = cifsd_sendmsg_notify(work->sess,
+			sizeof(inotify_req_info)+path_len,
+			&inotify_req_info, path);
+
+		rsp->hdr.Status = NT_STATUS_OK;
+		rsp->StructureSize = cpu_to_le16(9);
+		rsp->OutputBufferOffset = cpu_to_le16(72);
+		rsp->OutputBufferLength =
+		work->sess->inotify_res->output_buffer_length;
+
+		memcpy(rsp->Buffer,
+			&(work->sess->inotify_res->file_notify_info[0]),
+			sizeof(struct FileNotifyInformation) + NAME_MAX);
+		inc_rfc1001_len(rsp_org, 8 + rsp->OutputBufferLength);
+		smb_send_rsp(work);
+		kfree(path_buf);
+		kfree(work->sess->inotify_res);
+	}
+
+out1:
+	smb_work->send_no_response = 1;
+	return 0;
+
+out2:
+	if (rsp->hdr.Status == 0)
+		rsp->hdr.Status = NT_STATUS_NOT_SUPPORTED;
+	smb2_set_err_rsp(smb_work);
 	return rc;
 }
 


### PR DESCRIPTION
When kernel get multiple notify requests for a file,
put them in fp->queue and send it to user space daemon one by one.
It ensures that user space daemon handles only one inotify request
for a file at a time.

** Please check cifsd-tools repo also.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>