### PR TITLE
cifsd: add NULL check to fix an oops

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -468,6 +468,10 @@ int close_id(struct cifsd_sess *sess, uint64_t id, uint64_t p_id)
 	struct cifsd_lock *lock, *tmp;
 	int err;
 
+	if (!sess) {
+		cifsd_err("Session is NULL!\n");
+		return -EINVAL;
+	}
 	if (IS_SMB2(sess->conn)) {
 		fp = cifsd_get_global_fp(p_id);
 		if (!fp || fp->sess != sess) {


### PR DESCRIPTION
I found an oops issue during testing notify patch and add a NULL check to fix it.

[0-5130.0171] Unable to handle kernel NULL pointer dereference at virtual address 00000004
[0-5130.0171] pgd = c0003000
[0-5130.0171] [00000004] *pgd=80000040004003, *pmd=00000000
[0-5130.0171] [1004000.tmcetf] coresight buffer sink !!
[0-5130.0173] coresight-tmc 1004000.tmcetf: TMC read start
[0-5130.0173] coresight-tmc 1004000.tmcetf: TMC read end
[0-5130.0173] ================================================================================
[0-5130.0174]  SMP Send Stop Other CPU!
[0-5130.0174] ================================================================================
...
[0-5130.0214] CPU: 0 PID: 204 Comm: kworker/0:2 Tainted: PO 4.1.10 #42
[0-5130.0214] SCHED_NORMAL (p:120, static_p:120, normal_p:120, rt_p:0)
[0-5130.0214] Hardware name: Samsung SDP1601(Flattened Device Tree)
[0-5130.0214] Workqueue: events handle_smb_work
[0-5130.0214] task: e0f7b840 ti: dda2c000 task.ti: dda2c000
[0-5130.0214] PC is at close_id+0x18/0x3c0
[0-5130.0214] LR is at close_disconnected_handle+0xa8/0xc4
[0-5130.0214] pc : [<c027b798>]    lr : [<c02962cc>]    psr: 60010013
[0-5130.0214] sp : dda2dce8  ip : dda2dd38  fp : dda2dd34
[0-5130.0214] r10: ddfa5300  r9 : 00000000  r8 : 00000004
[0-5130.0214] r7 : 00000001  r6 : dc84c300  r5 : dc84c32c  r4 : dd4d3600
[0-5130.0214] r3 : 00000000  r2 : 00000004  r1 : dd4d3a00  r0 : 00000000
[0-5130.0214] Flags: nZCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment kernel
[0-5130.0214] Control: 30c5383d  Table: 947bb000  DAC: 55555555
[0-5130.0214] Process kworker/0:2 (pid: 204, stack limit = 0xdda2c210)
[0-5130.0214] Stack: (0xdda2dce8 to 0xdda2e000)
[0-5130.0214] dce0:                   dc84c300 dfb58620 dda2dd0c dda2dd00 c0667c7c c005a1c8
[0-5130.0214] dd00: dda2dd34 dda2dd10 c027b300 dd4d3600 dc84c32c dc84c300 00000001 00000004
[0-5130.0214] dd20: 00000000 ddfa5300 dda2dd64 dda2dd38 c02962cc c027b78c 00000004 00000000
[0-5130.0214] dd40: 00000000 ddab1180 dcaae080 c0aa4cb0 df64b700 00000000 dda2de84 dda2dd68
[0-5130.0214] dd60: c0299b94 c0296230 dda2dda4 dda2dd78 c00a1560 c04e8ec0 006c2787 00000400
[0-5130.0214] dd80: c0a72840 c0a72840 be95f3b4 dda2de1c e100bc00 c007003c 001f01ff 00000003
[0-5130.0214] dda0: dda2ddd4 df59b540 00000000 00000000 00000000 dda2c010 00000000 00000000
[0-5130.0214] ddc0: 00000000 dda2ddd0 c018242c 00000000 00000000 dda2ddf8 ddfd2140 dda58b00
[0-5130.0214] dde0: dcb1a940 df64b700 00000000 00000000 00000000 c006e9f8 ddfcde10 dfbcf858
[0-5130.0215] de00: dda2de1c dda2de10 00000019 00000000 00800001 dda281ed 00000001 00000000
[0-5130.0215] de20: 00000000 00000000 00000000 00000000 12cea600 00000000 12cea600 00000000
[0-5130.0215] de40: 12cea600 00000000 00000200 ddab1180 00000000 00000000 dda2de84 c0938c28
[0-5130.0215] de60: dcb1a940 ddab119c c0aa4cb0 ddab1180 00000005 dcb1a964 dda2dec4 dda2de88
[0-5130.0215] de80: c027656c c02991d0 c00602fc c00a1534 dcb1aa00 00000000 c0072554 ddab119c
[0-5130.0215] dea0: dde32c80 e14de3e4 e14de3c0 e14e1f00 00000000 00000000 dda2df04 dda2dec8
[0-5130.0215] dec0: c0047fc0 c02762a4 e14de3c0 e14de3c0 e14de3e4 dda2c000 00000008 e14de3c0
[0-5130.0215] dee0: dde32c98 e14de3e4 dda2c000 00000008 dde32c80 e14de3c0 dda2df3c dda2df08
[0-5130.0215] df00: c004832c c0047e8c c00482d8 c090c100 00000000 00000000 ddfc0300 dde32c80
[0-5130.0215] df20: c00482d8 00000000 00000000 00000000 dda2dfac dda2df40 c004de54 c00482e4
[0-5130.0215] df40: dda2df64 00000000 c0072554 dde32c80 00000000 00000000 dead4ead ffffffff
[0-5130.0215] df60: ffffffff 00000000 dda2df68 dda2df68 00000000 00000000 dead4ead ffffffff
[0-5130.0215] df80: ffffffff 00000000 dda2df88 dda2df88 ddfc0300 c004dd68 00000000 00000000
[0-5130.0215] dfa0: 00000000 dda2dfb0 c000ff18 c004dd74 00000000 00000000 00000000 00000000
[0-5130.0215] dfc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[0-5130.0215] dfe0: 00000000 00000000 00000000 00000000 00000013 00000000 ad5e9cc4 d1f15b99
[0-5130.0215] Backtrace: 
[0-5130.0215] [<c027b780>] (close_id) from [<c02962cc>] (close_disconnected_handle+0xa8/0xc4)
[0-5130.0215]  r10:ddfa5300 r9:00000000 r8:00000004 r7:00000001 r6:dc84c300 r5:dc84c32c
[0-5130.0215]  r4:dd4d3600
[0-5130.0215] [<c0296224>] (close_disconnected_handle) from [<c0299b94>] (smb2_open+0x9d0/0x273c)
[0-5130.0215]  r9:00000000 r8:df64b700 r7:c0aa4cb0 r6:dcaae080 r5:ddab1180 r4:00000000
[0-5130.0216] [<c02991c4>] (smb2_open) from [<c027656c>] (handle_smb_work+0x2d4/0x658)
[0-5130.0216]  r10:dcb1a964 r9:00000005 r8:ddab1180 r7:c0aa4cb0 r6:ddab119c r5:dcb1a940
[0-5130.0216]  r4:c0938c28
[0-5130.0216] [<c0276298>] (handle_smb_work) from [<c0047fc0>] (process_one_work+0x140/0x458)
[0-5130.0216]  r10:00000000 r9:00000000 r8:e14e1f00 r7:e14de3c0 r6:e14de3e4 r5:dde32c80
[0-5130.0216]  r4:ddab119c
[0-5130.0216] [<c0047e80>] (process_one_work) from [<c004832c>] (worker_thread+0x54/0x4b8)
[0-5130.0216]  r10:e14de3c0 r9:dde32c80 r8:00000008 r7:dda2c000 r6:e14de3e4 r5:dde32c98
[0-5130.0216]  r4:e14de3c0
[0-5130.0216] [<c00482d8>] (worker_thread) from [<c004de54>] (kthread+0xec/0x104)
[0-5130.0216]  r10:00000000 r9:00000000 r8:00000000 r7:c00482d8 r6:dde32c80 r5:ddfc0300
[0-5130.0216]  r4:00000000
[0-5130.0216] [<c004dd68>] (kthread) from [<c000ff18>] (ret_from_fork+0x14/0x3c)
[0-5130.0216]  r7:00000000 r6:00000000 r5:c004dd68 r4:ddfc0300
[0-5130.0216] Code: e24cb004 e24dd024 e52de004 e8bd4000 (e5901004) 

Signed-off-by: Taeyang Mok <t.mok@samsung.com>