### PR TITLE
cifsd: fixed oops from getting logical sector size

### DIFF
--- a/vfs.c
+++ b/vfs.c
@@ -1313,9 +1313,11 @@ out:
 unsigned short get_logical_sector_size(struct inode *inode)
 {
 	struct request_queue *q;
-	unsigned short ret_val;
+	unsigned short ret_val = 512;
 
-	ret_val = 512;
+	if(!inode->i_sb->s_bdev)
+		return ret_val;
+
 	q = inode->i_sb->s_bdev->bd_disk->queue;
 
 	if (q && q->limits.logical_block_size)


### PR DESCRIPTION
kernel NULL pointer dereference at
[0-124.8900] [<c02282c8>] (get_logical_sector_size) from [<c0243748>] (smb2_get_info_filesystem+0x424/0x618)
[0-124.8901] [<c0243324>] (smb2_get_info_filesystem) from [<c0243af8>] (smb2_query_info+0x1bc/0x2f4)

The inode->i_sb->s_bdev was NULL on tmpfs.

Signed-off-by: Yunjae Lim <yunjae.lim@samsung.com>