### PR TITLE
Kconfig: add CONFIG_KEYS dependency

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2,6 +2,7 @@ config CIFS_SERVER
 	tristate "CIFS server support"
 	depends on INET
 	select NLS
+	select KEYS
 	select CRYPTO
 	select CRYPTO_MD4
 	select CRYPTO_MD5


### PR DESCRIPTION
We need to select CONFIG_KEYS to enable linux/key-type.h, otherwise
we get build errors:

cifsacl.c:74:52: warning: ‘struct key_preparsed_payload’ declared inside parameter list will not be visible outside of this definition or declaration
 cifs_idmap_key_instantiate(struct key *key, struct key_preparsed_payload *prep)
                                                    ^~~~~~~~~~~~~~~~~~~~~
cifsacl.c: In function ‘cifs_idmap_key_instantiate’:
cifsacl.c:86:10: error: dereferencing pointer to incomplete type ‘struct key_preparsed_payload’
  if (prep->datalen <= sizeof(key->payload)) {
          ^~
cifsacl.c:86:33: error: dereferencing pointer to incomplete type ‘struct key’
  if (prep->datalen <= sizeof(key->payload)) {
                                 ^~
cifsacl.c: At top level:
cifsacl.c:121:15: error: variable ‘cifsd_idmap_key_type’ has initializer but incomplete type
 static struct key_type cifsd_idmap_key_type = {
               ^~~~~~~~
cifsacl.c:122:3: error: ‘struct key_type’ has no member named ‘name’
  .name        = "cifs.idmap",
   ^~~~
cifsacl.c:122:17: warning: excess elements in struct initializer
  .name        = "cifs.idmap",
                 ^~~~~~~~~~~~
and so on.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>