### PR TITLE
srv: work-around 4.16 build error

### DIFF
--- a/srv.c
+++ b/srv.c
@@ -788,13 +788,25 @@ int connect_tcp_sess(struct socket *sock)
 {
 	struct sockaddr_storage caddr;
 	struct sockaddr *csin = (struct sockaddr *)&caddr;
-	int rc = 0, cslen;
+	int rc = 0;
 	struct connection *conn;
+
+/*
+ * FIXME this is ugly, must be dropped.
+ */
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 15, 0)
+	int cslen;
 
 	if (kernel_getpeername(sock, csin, &cslen) < 0) {
 		cifsd_err("client ip resolution failed\n");
 		return -EINVAL;
 	}
+#else
+	if (kernel_getpeername(sock, csin) < 0) {
+		cifsd_err("client ip resolution failed\n");
+		return -EINVAL;
+	}
+#endif
 
 	conn = kzalloc(sizeof(struct connection), GFP_KERNEL);
 	if (conn == NULL) {


### PR DESCRIPTION
commit "net: make getname() functions return length rather than
use int* parameter" has dropped some arguments from a number of
net/ functions. We are using one of those functions, namely,
kernel_getpeername() - which now requires only 2 params.

This is quite annoying, so make a temp (!) fix, which must be
dropped when we will push cifsd upstream.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>