### PR TITLE
cifsd: slightly improve user/share validation

### DIFF
--- a/export.h
+++ b/export.h
@@ -220,9 +220,6 @@ extern int get_protocol_idx(char *str);
 extern int cifsd_init_registry(void);
 extern void cifsd_free_registry(void);
 extern struct cifsd_share *find_matching_share(__u16 tid);
-int validate_usr(struct cifsd_sess *sess, struct cifsd_share *share,
-	bool *can_write);
-int validate_host(char *cip, struct cifsd_share *share);
 int process_ntlm(struct cifsd_sess *sess, char *pw_buf);
 int process_ntlmv2(struct cifsd_sess *sess, struct ntlmv2_resp *ntlmv2,
 		int blen, char *domain_name);


### PR DESCRIPTION
Tweak chktkn():
a) do not duplicate memory (strsep() modifies
   original string)
b) rename it to conflist_search(), because the functions, basically,
   checks if a key exists in a list (tabs, commas, spaces separated
   smb.conf list)

$ size cifsd.o cifsd.o.new
   text	   data	    bss	    dec	    hex	filename
 228177	   7948	    257	 236382	  39b5e	cifsd.o
 227951	   7948	    257	 236156	  39a7c	cifsd.o.new

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>