### PR TITLE
cifsd: initial version of a new user management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ obj-$(CONFIG_CIFS_SERVER) += cifsd.o
 
 cifsd-y := 	export.o connect.o srv.o unicode.o encrypt.o auth.o \
 		fh.o vfs.o misc.o smb1pdu.o smb1ops.o oplock.o netmisc.o \
-		netlink.o cifsacl.o
+		netlink.o cifsacl.o management/user.o
 
 cifsd-$(CONFIG_CIFS_SMB2_SERVER) += smb2pdu.o smb2ops.o asn1.o

--- a/export.h
+++ b/export.h
@@ -25,6 +25,8 @@
 #include "smb1pdu.h"
 #include "ntlmssp.h"
 
+#include "management/user.h"
+
 #ifdef CONFIG_CIFS_SMB2_SERVER
 #include "smb2pdu.h"
 #endif
@@ -35,7 +37,6 @@
 extern int cifsd_debug_enable;
 
 /* Global list containing exported points */
-extern struct list_head cifsd_usr_list;
 extern struct list_head cifsd_share_list;
 extern struct list_head cifsd_connection_list;
 extern struct list_head cifsd_session_list;
@@ -87,24 +88,9 @@ enum {
 	MANDATORY
 };
 
-struct cifsd_usr {
-	char	*name;
-	char	*passkey; /* max size CIFS_NTHASH_SIZE */
-	kuid_t	uid;
-	kgid_t	gid;
-	__le32	sess_uid;
-	bool	guest;
-	/* global list of cifsd users */
-	struct	list_head list;
-	__u16	vuid;
-	/* how many connection have this user */
-	int	ucount;
-	/* unsigned int capabilities; what for */
-};
-
-/* cifsd_sess coupled with cifsd_usr */
+/* cifsd_sess coupled with cifsd_user */
 struct cifsd_sess {
-	struct cifsd_usr *usr;
+	struct cifsd_user *user;
 	struct connection *conn;
 	struct list_head cifsd_ses_list;
 	struct list_head cifsd_ses_global_list;
@@ -238,14 +224,14 @@ int smb3_sign_smbpdu(struct channel *chann, struct kvec *iov, int n_vec,
 int compute_sess_key(struct cifsd_sess *sess, char *hash, char *hmac);
 int compute_smb3xsigningkey(struct cifsd_sess *sess,  __u8 *key,
 	unsigned int key_size);
-extern struct cifsd_usr *cifsd_is_user_present(char *name);
+extern struct cifsd_user *cifsd_is_user_present(char *name);
 struct cifsd_share *get_cifsd_share(struct connection *conn,
 		struct cifsd_sess *sess, char *sharename, bool *can_write);
 extern struct cifsd_tcon *construct_cifsd_tcon(struct cifsd_share *share,
 		struct cifsd_sess *sess);
 extern struct cifsd_tcon *get_cifsd_tcon(struct cifsd_sess *sess,
 			unsigned int tid);
-struct cifsd_usr *get_smb_session_user(struct cifsd_sess *sess);
+struct cifsd_user *get_smb_session_user(struct cifsd_sess *sess);
 struct cifsd_pipe *get_pipe_desc(struct cifsd_sess *sess,
 		unsigned int id);
 int get_pipe_id(struct cifsd_sess *sess, unsigned int pipe_type);

--- a/management/user.c
+++ b/management/user.c
@@ -1,0 +1,189 @@
+/*
+ *   Copyright (C) 2018 Samsung Electronics Co., Ltd.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+
+#include <linux/jhash.h>
+#include <linux/spinlock.h>
+#include <linux/slab.h>
+#include <linux/rwsem.h>
+
+#include "user.h"
+
+static unsigned short global_smb1_vuids;
+static DEFINE_SPINLOCK(global_vuids_lock);
+
+#define USERS_HASH_BITS		3
+static DEFINE_HASHTABLE(users_table, USERS_HASH_BITS);
+static DECLARE_RWSEM(users_table_lock);
+
+static unsigned short get_next_vuid(void)
+{
+	unsigned short v;
+
+	spin_lock(&global_vuids_lock);
+	v = global_smb1_vuids++;
+	spin_unlock(&global_vuids_lock);
+	return v;
+}
+
+static unsigned int um_hash(char *name)
+{
+	return jhash(name, strlen(name), 0);
+}
+
+static void um_kill_user(struct cifsd_user *user)
+{
+	kfree(user);
+}
+
+static void deferred_user_free(struct work_struct *work)
+{
+	struct cifsd_user *user = container_of(work,
+					       struct cifsd_user,
+					       free_work);
+
+	down_write(&users_table_lock);
+	hash_del(&user->hlist);
+	up_write(&users_table_lock);
+	um_kill_user(user);
+}
+
+void __put_cifsd_user(struct cifsd_user *user)
+{
+	schedule_work(&user->free_work);
+}
+
+static struct cifsd_user *__um_user_search(char *name)
+{
+	struct cifsd_user *user;
+	unsigned int key = um_hash(name);
+
+	hash_for_each_possible(users_table, user, hlist, key) {
+		if (!strcmp(name, user->name))
+			return user;
+	}
+	return NULL;
+}
+
+struct cifsd_user *um_user_search(char *name)
+{
+	struct cifsd_user *user, *ret = NULL;
+
+	down_read(&users_table_lock);
+	user = __um_user_search(name);
+	/*
+	 * Check that we can get user struct. get_cifsd_user()
+	 * will return NULL if cifsd_user is going to be freed
+	 * soon.
+	 */
+	if (user)
+		ret = get_cifsd_user(user);
+	up_read(&users_table_lock);
+	return ret;
+}
+
+struct cifsd_user *um_user_search_guest(void)
+{
+	struct cifsd_user *user, *ret = NULL;
+	int i;
+
+	down_read(&users_table_lock);
+	hash_for_each(users_table, i, user, hlist) {
+		if (user_guest(user)) {
+			ret = get_cifsd_user(user);
+			if (ret)
+				break;
+		}
+	}
+	up_read(&users_table_lock);
+	return ret;
+}
+
+static void __um_add_new_user(struct cifsd_user *user,
+			      char *name,
+			      char *pass,
+			      kuid_t uid,
+			      kgid_t gid)
+{
+	user->name = name;
+	user->passkey = pass;
+	user->uid.val = uid.val;
+	user->gid.val = gid.val;
+
+	user->smb1_vuid = get_next_vuid();
+	refcount_set(&user->refcount, 1);
+
+	INIT_WORK(&user->free_work, deferred_user_free);
+	hash_add(users_table, &user->hlist, um_hash(name));
+}
+
+int um_add_new_user(char *name, char *pass, kuid_t uid, kgid_t gid)
+{
+	struct cifsd_user *user;
+
+	/* GFP_KERNEL allocation, pre-allocate user out of users_table_lock */
+	user = kzalloc(sizeof(struct cifsd_user), GFP_KERNEL);
+	if (!user)
+		return -ENOMEM;
+
+	down_write(&users_table_lock);
+	if (__um_user_search(name)) {
+		up_write(&users_table_lock);
+		um_kill_user(user);
+		return -EEXIST;
+	}
+
+	__um_add_new_user(user, name, pass, uid, gid);
+	up_write(&users_table_lock);
+	return 0;
+}
+
+int um_delete_user(char *name)
+{
+	struct cifsd_user *user;
+	int ret = -EINVAL;
+
+	down_write(&users_table_lock);
+	user = __um_user_search(name);
+	if (user && !(user->flags & UF_PENDING_REMOVAL)) {
+		user->flags |= UF_PENDING_REMOVAL;
+		put_cifsd_user(user);
+		ret = 0;
+	}
+	up_write(&users_table_lock);
+	return ret;
+}
+
+void um_cleanup_users(void)
+{
+	struct cifsd_user *user;
+	struct hlist_node *tmp;
+	int i;
+
+	down_write(&users_table_lock);
+	hash_for_each_safe(users_table, i, tmp, user, hlist) {
+		hash_del(&user->hlist);
+		kfree(user);
+	}
+	up_write(&users_table_lock);
+}
+
+size_t um_users_show(char *buf, size_t sz)
+{
+	/* Not supported */
+	return 0;
+}

--- a/management/user.h
+++ b/management/user.h
@@ -1,0 +1,104 @@
+/*
+ *   Copyright (C) 2018 Samsung Electronics Co., Ltd.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+
+#ifndef __USER_MANAGEMENT_H__
+#define __USER_MANAGEMENT_H__
+
+#include <linux/refcount.h>
+#include <linux/workqueue.h>
+#include <linux/hashtable.h>
+
+#define UF_GUEST_ACCOUNT	(1 << 0)
+#define UF_PENDING_REMOVAL	(1 << 1)
+
+struct cifsd_user {
+	char			*name;
+	/* Max size CIFS_NTHASH_SIZE */
+	char			*passkey;
+
+	kuid_t			uid;
+	kgid_t			gid;
+
+	refcount_t		refcount;
+	struct hlist_node	hlist;
+	struct work_struct	free_work;
+
+	unsigned short		smb1_vuid;
+	unsigned short		flags;
+};
+
+extern void __put_cifsd_user(struct cifsd_user *user);
+
+static inline void put_cifsd_user(struct cifsd_user *user)
+{
+	if (!refcount_dec_and_test(&user->refcount))
+		return;
+	__put_cifsd_user(user);
+}
+
+static inline struct cifsd_user *get_cifsd_user(struct cifsd_user *user)
+{
+	if (!refcount_inc_not_zero(&user->refcount))
+		return NULL;
+	return user;
+}
+
+static inline bool user_guest(struct cifsd_user *user)
+{
+	return user->flags & UF_GUEST_ACCOUNT;
+}
+
+static inline void set_user_guest(struct cifsd_user *user)
+{
+	user->flags |= UF_GUEST_ACCOUNT;
+	user->smb1_vuid = 0;
+}
+
+static inline unsigned short user_smb1_vuid(struct cifsd_user *user)
+{
+	return user->smb1_vuid;
+}
+
+static inline char *user_passkey(struct cifsd_user *user)
+{
+	return user->passkey;
+}
+
+static inline char *user_name(struct cifsd_user *user)
+{
+	return user->name;
+}
+
+static inline kuid_t user_uid(struct cifsd_user *user)
+{
+	return user->uid;
+}
+
+static inline kgid_t user_gid(struct cifsd_user *user)
+{
+	return user->gid;
+}
+
+struct cifsd_user *um_user_search(char *name);
+struct cifsd_user *um_user_search_guest(void);
+int um_add_new_user(char *name, char *pass, kuid_t uid, kgid_t gid);
+int um_delete_user(char *name);
+void um_cleanup_users(void);
+size_t um_users_show(char *buf, size_t sz);
+
+#endif /* __USER_MANAGEMENT_H__ */

--- a/netlink.c
+++ b/netlink.c
@@ -76,7 +76,7 @@ int cifsd_sendmsg(struct cifsd_sess *sess, unsigned int etype,
 	struct cifsd_uevent *ev;
 	int len = nlmsg_total_size(sizeof(*ev) + data_size);
 	int rc;
-	struct cifsd_usr *user;
+	struct cifsd_user *user;
 	struct cifsd_pipe *pipe_desc = sess->pipe_desc[pipe_type];
 
 	if (unlikely(!pipe_desc))
@@ -126,7 +126,7 @@ int cifsd_sendmsg(struct cifsd_sess *sess, unsigned int etype,
 				CIFSD_CODEPAGE_LEN - 1);
 		user = get_smb_session_user(sess);
 		if (user)
-			strncpy(ev->k.l_pipe.username, user->name,
+			strncpy(ev->k.l_pipe.username, user_name(user),
 					CIFSD_USERNAME_LEN - 1);
 		break;
 	default:


### PR DESCRIPTION
This patch is a first bit of resource management rework. In this patch
we change we way we manage users. The bits of user management now moved
to a new file - user_management.c, which encapsulates all the internal
details, which previously were spread across the system.

First change,

- we used to have a global list of all registered users
  This forced us to do costly for_each() lookups in search for user
  name match, which is O(n) operation. The more users we have - the
  longer it takes to logon and so on.

  Besides, we should not export users list. It's a very internal detail
  which must be known only to user management code.

  We now use hash table.

Second change,

- our user list was not protected from concurrent modifications.
  It was perfectly possible to have CPU1 iterating the list, while CPU0
  could have remove entries concurrently.

  We now protect user table for concurrent modifications by
  readers-writer lock. There can be N CPUs doing lookup and only one
  CPU performing modifications.

Third change,

- our users/sessions were not protected from concurrent changes.

  Basically, we could have kfree(user) and list_del(user) while the
  user was still active - logged-on. Because we cifsadmin command
  handler didn't care to check if the user struct was still in use.

  Now we have a reference count based user management. Each time we
  grad the ownership of a user structure we increment its refcounter,
  each time we put the user struct - we decrement it. The default
  value is 1. When we have a new logon request, we assign user to a
  session, thus user refcounter becomes 2. When we have logoff we
  put user structure which was previously assigned to a sessions - so
  the refcounter value becomes 1 again.

  If we have cifsadmin request to delete the user - all it does is
  decrementing refcounter by 1. Just once. So if the user is active,
  its reference counter will not become 0. It's only when the user
  will logoff and put its user struct the refcounter will go down to
  0 and thus we will schedule a user deletion work.

  So we have a deferred user deletion now, which is handler by a
  system wq.

Like I said, the patch is in initial stage, it passes my tests but
more work is required.

We gonna do the same for shares and other resources.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>