### PR TITLE
cifsd: fixed SMB negoiate response for the wildcard dialect revision

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -1073,6 +1073,10 @@ int smb2_negotiate(struct smb_work *smb_work)
 	case SMB20_PROT_ID:
 		init_smb2_0_server(conn);
 		break;
+	case SMB2X_PROT_ID:
+		cifsd_err("Server dialect :0x%x not supported\n", conn->dialect);
+		rsp->hdr.Status = NT_STATUS_NOT_SUPPORTED;
+		break;
 	case BAD_PROT_ID:
 	default:
 		cifsd_err("Server dialect :0x%x not supported\n", conn->dialect);


### PR DESCRIPTION
MS testsuite: Fileserver > NegotiateTestCaseS2219

In case of Dialect: 0x02ff in SMB2 negotiate request, the STATUS_NOT_SUPPORTED response should be sent.
It also should consider the SMB1 negotiate request with dialects.

Signed-off-by: Yunjae Lim <yunjae.lim@samsung.com>