### PR TITLE
cifsd: fixed the SMB2 negotiate response to the wrong dialect count

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -1028,6 +1028,8 @@ int smb2_negotiate(struct smb_work *smb_work)
 	struct timespec ts;
 #endif
 
+	cifsd_debug("Recieved negotiate request\n");
+
 	req = (struct smb2_negotiate_req *)smb_work->buf;
 	rsp = (struct smb2_negotiate_rsp *)smb_work->rsp_buf;
 
@@ -1037,10 +1039,10 @@ int smb2_negotiate(struct smb_work *smb_work)
 		return 0;
 	}
 
-	cifsd_debug("%s: Recieved negotiate request\n", __func__);
 	if (req->StructureSize != 36 || req->DialectCount == 0) {
 		cifsd_err("malformed packet\n");
-		smb_work->send_no_response = 1;
+		rsp->hdr.Status = NT_STATUS_INVALID_PARAMETER;
+		smb2_set_err_rsp(smb_work);
 		return 0;
 	}
 


### PR DESCRIPTION
MS testsuite: Fileserver > NegotiateTestCaseS2133

This testcase sends the SMB2 request with the wrong dialect count.
The SMB2 error response should be sent with STATUS_INVALID_PARAMETER (0xc000000d).

Signed-off-by: Yunjae Lim <yunjae.lim@samsung.com>