### PR TITLE
[PATCH 0/3] add some information levels for trans2 commands

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -6160,10 +6160,13 @@ int find_first(struct smb_work *smb_work)
 				MAX_CIFS_LOOKUP_BUFFER_SIZE - header_size);
 
 	/* reserve dot and dotdot entries in head of buffer in first response */
-	rc = smb_populate_dot_dotdot_entries(conn, req_params->InformationLevel,
-		dir_fp, &d_info, srch_ptr, smb_populate_readdir_entry);
-	if (rc)
-		goto err_out;
+	if (!*srch_ptr) {
+		rc = smb_populate_dot_dotdot_entries(conn,
+			req_params->InformationLevel, dir_fp, &d_info,
+			srch_ptr, smb_populate_readdir_entry);
+		if (rc)
+			goto err_out;
+	}
 
 	do {
 		if (dir_fp->dirent_offset >= dir_fp->readdir_data.used) {

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -7211,6 +7211,7 @@ int set_file_info(struct smb_work *smb_work)
 		err = smb_set_unix_fileinfo(smb_work);
 		break;
 	case SMB_SET_FILE_DISPOSITION_INFO:
+	case SMB_SET_FILE_DISPOSITION_INFORMATION:
 		err = smb_set_dispostion(smb_work);
 		break;
 	case SMB_SET_FILE_BASIC_INFO2:

--- a/smb1pdu.h
+++ b/smb1pdu.h
@@ -1184,6 +1184,7 @@ typedef struct {
 #define SMB_SET_FILE_UNIX_INFO2         0x20b
 #define SMB_SET_FILE_BASIC_INFO2        0x3ec
 #define SMB_SET_FILE_RENAME_INFORMATION 0x3f2 /* BB check if qpathinfo too */
+#define SMB_SET_FILE_DISPOSITION_INFORMATION   0x3f5   /* alias for 0x102 */
 #define SMB_FILE_ALL_INFO2              0x3fa
 #define SMB_SET_FILE_ALLOCATION_INFO2   0x3fb
 #define SMB_SET_FILE_END_OF_FILE_INFO2  0x3fc

--- a/smb1pdu.h
+++ b/smb1pdu.h
@@ -1495,6 +1495,35 @@ extern int get_dfs_referral(struct smb_work *smb_work);
 /* FIND FIRST2 and FIND NEXT2 INFOMATION Level Codes*/
 
 typedef struct {
+	__le16 CreationDate; /* SMB Date see above */
+	__le16 CreationTime; /* SMB Time */
+	__le16 LastAccessDate;
+	__le16 LastAccessTime;
+	__le16 LastWriteDate;
+	__le16 LastWriteTime;
+	__le32 DataSize; /* File Size (EOF) */
+	__le32 AllocationSize;
+	__le16 Attributes; /* verify not u32 */
+	__le16 FileNameLength;
+	char FileName[1];
+} __attribute__((packed)) FIND_INFO_STANDARD;
+
+typedef struct {
+	__le16 CreationDate; /* SMB Date see above */
+	__le16 CreationTime; /* SMB Time */
+	__le16 LastAccessDate;
+	__le16 LastAccessTime;
+	__le16 LastWriteDate;
+	__le16 LastWriteTime;
+	__le32 DataSize; /* File Size (EOF) */
+	__le32 AllocationSize;
+	__le16 Attributes; /* verify not u32 */
+	__le32 EASize;
+	__u8 FileNameLength;
+	char FileName[1];
+} __attribute__((packed)) FIND_INFO_QUERY_EA_SIZE;
+
+typedef struct {
 	__le32 NextEntryOffset;
 	__u32 FileIndex;
 	__le64 CreationTime;


### PR DESCRIPTION
This patch set is to fix a bug and no-implementation erros
which were found with torture raw.search.
A find_first bug is fiexed and some missed information levels for
trans2 commands are added.

Taeyang Mok (3):
  cifsd: add an alias for an information level
  cifsd: add 4 informaion levels
  cifsd: ignore dot_dotdot entries

 smb1pdu.c | 136 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
 smb1pdu.h |  30 ++++++++++++++
 2 files changed, 162 insertions(+), 4 deletions(-)

-- 
1.9.1