### PR TITLE
cifsd: drop some of unused LINUX_VERSION_CODE if-s

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -1014,9 +1014,7 @@ bool is_dir_empty(struct cifsd_file *fp)
 	struct path dir_path;
 	struct file *filp;
 	struct smb_readdir_data r_data = {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		.ctx.actor = smb_filldir,
-#endif
 		.dirent = (void *)__get_free_page(GFP_KERNEL),
 		.dirent_count = 0
 	};
@@ -1110,9 +1108,7 @@ int smb_search_dir(char *dirname, char *filename)
 	int dirnamelen = strlen(dirname);
 	bool match_found = false;
 	struct smb_readdir_data readdir_data = {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		.ctx.actor = smb_filldir,
-#endif
 		.dirent = (void *)__get_free_page(GFP_KERNEL)
 	};
 
@@ -1148,13 +1144,8 @@ int smb_search_dir(char *dirname, char *filename)
 			reclen = ALIGN(sizeof(struct smb_dirent) +
 				       buf_p->namelen, sizeof(__le64));
 			length = buf_p->namelen;
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 			if (length != namelen ||
 				strncasecmp(filename, buf_p->name, namelen))
-#else
-			if (length != namelen ||
-				strnicmp(filename, buf_p->name, namelen))
-#endif
 				continue;
 			/* got match, make absolute name */
 			memcpy(dirname + dirnamelen + 1, buf_p->name, namelen);

--- a/fh.h
+++ b/fh.h
@@ -68,9 +68,7 @@ struct cifsd_tcp_conn;
 struct cifsd_sess;
 
 struct smb_readdir_data {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 	struct dir_context ctx;
-#endif
 	char           *dirent;
 	unsigned int   used;
 	unsigned int   full;

--- a/glob.h
+++ b/glob.h
@@ -47,10 +47,8 @@
 #include <linux/namei.h>
 #include <linux/version.h>
 #include <linux/fdtable.h>
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 #include <linux/vmalloc.h>
 #include <uapi/linux/xattr.h>
-#endif
 #include <linux/hashtable.h>
 #include "unicode.h"
 #include "fh.h"
@@ -628,13 +626,8 @@ char *convert_to_unix_name(char *name, int tid);
 void convert_delimiter(char *path, int flags);
 int find_first(struct smb_work *smb_work);
 int find_next(struct smb_work *smb_work);
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 int smb_filldir(struct dir_context *ctx, const char *name, int namlen,
 		loff_t offset, u64 ino, unsigned int d_type);
-#else
-int smb_filldir(void *__buf, const char *name, int namlen,
-		loff_t offset, u64 ino, unsigned int d_type);
-#endif
 int smb_get_shortname(struct cifsd_tcp_conn *conn, char *longname,
 		char *shortname);
 char *read_next_entry(struct smb_work *smb_work, struct smb_kstat *smb_kstat,

--- a/misc.c
+++ b/misc.c
@@ -21,9 +21,7 @@
 
 #include <linux/kernel.h>
 #include <linux/version.h>
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 #include <linux/xattr.h>
-#endif
 
 #include "glob.h"
 #include "export.h"

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -3465,22 +3465,14 @@ int unix_info_to_attr(FILE_UNIX_BASIC_INFO *unix_info,
 	}
 
 	if (le64_to_cpu(unix_info->Uid) != NO_CHANGE_64) {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		attrs->ia_uid = make_kuid(&init_user_ns,
 				le64_to_cpu(unix_info->Uid));
-#else
-		attrs->ia_uid = le64_to_cpu(unix_info->Uid);
-#endif
 		attrs->ia_valid |= ATTR_UID;
 	}
 
 	if (le64_to_cpu(unix_info->Gid) != NO_CHANGE_64) {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		attrs->ia_gid =  make_kgid(&init_user_ns,
 				le64_to_cpu(unix_info->Gid));
-#else
-		attrs->ia_gid = le64_to_cpu(unix_info->Gid);
-#endif
 		attrs->ia_valid |= ATTR_GID;
 	}
 
@@ -5705,20 +5697,11 @@ int set_path_info(struct smb_work *smb_work)
  *
  * Return:	0 on success, otherwise -EINVAL
  */
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 int smb_filldir(struct dir_context *ctx, const char *name, int namlen,
 		loff_t offset, u64 ino, unsigned int d_type)
-#else
-int smb_filldir(void *__buf, const char *name, int namlen,
-		loff_t offset, u64 ino, unsigned int d_type)
-#endif
 {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 	struct smb_readdir_data *buf =
 		container_of(ctx, struct smb_readdir_data, ctx);
-#else
-	struct smb_readdir_data *buf = __buf;
-#endif
 	struct smb_dirent *de = (void *)(buf->dirent + buf->used);
 	unsigned int reclen;
 
@@ -6283,9 +6266,7 @@ int find_first(struct smb_work *smb_work)
 	char *dirpath = NULL;
 	char *srch_ptr = NULL;
 	struct smb_readdir_data r_data = {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		.ctx.actor = smb_filldir,
-#endif
 		.dirent = (void *)__get_free_page(GFP_KERNEL)
 	};
 	int header_size;
@@ -6523,9 +6504,7 @@ int find_next(struct smb_work *smb_work)
 	char *name = NULL;
 	char *pathname = NULL;
 	struct smb_readdir_data r_data = {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		.ctx.actor = smb_filldir,
-#endif
 	};
 	int header_size;
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -3177,9 +3177,7 @@ int smb2_query_dir(struct smb_work *smb_work)
 	char *dirpath, *srch_ptr = NULL, *path = NULL;
 	unsigned char srch_flag;
 	struct smb_readdir_data r_data = {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 10, 30)
 		.ctx.actor = smb_filldir,
-#endif
 	};
 
 	req = (struct smb2_query_directory_req *)REQUEST_BUF(smb_work);


### PR DESCRIPTION
We don't support 3.10, so we can drop some of LINUX_VERSION_CODE
if-s. The remaining if-s are really ugly, we need to move out of
the core code as many of them as possible and put them into macros
or small one-liner helper functions.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>