### PR TITLE
tcp_conn API extension

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -437,12 +437,7 @@ int smb_session_disconnect(struct smb_work *smb_work)
 	put_cifsd_user(sess->user);
 	sess->user = NULL;
 
-	/*
-	 * We cannot discard session in case some request are already running.
-	 * Need to wait for them to finish and update req_running.
-	 */
-	wait_event(conn->req_running_q,
-			atomic_read(&conn->req_running) == 1);
+	cifsd_tcp_conn_wait_idle(conn);
 
 	/* free all tcons */
 	list_for_each_safe(tmp, t, &sess->tcon_list) {

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -1776,12 +1776,7 @@ int smb2_session_logoff(struct smb_work *smb_work)
 
 	destroy_fidtable(sess);
 
-	/*
-	 * We cannot discard session in case some request are already running.
-	 * Need to wait for them to finish and update req_running.
-	 */
-	wait_event(conn->req_running_q,
-			atomic_read(&conn->req_running) == 1);
+	cifsd_tcp_conn_wait_idle(conn);
 
 	/* Free the tree connection to session */
 	list_for_each_safe(tmp, t, &sess->tcon_list) {

--- a/transport.c
+++ b/transport.c
@@ -262,9 +262,6 @@ static int cifsd_tcp_conn_handler_loop(void *p)
 		}
 	}
 
-	wait_event(conn->req_running_q,
-				atomic_read(&conn->req_running) == 0);
-
 	/* Wait till all reference dropped to the Server object*/
 	while (atomic_read(&conn->r_count) > 0)
 		schedule_timeout(HZ);

--- a/transport.c
+++ b/transport.c
@@ -544,6 +544,11 @@ void cifsd_tcp_conn_unlock(struct cifsd_tcp_conn *conn)
 		wake_up_all(&conn->req_running_q);
 }
 
+void cifsd_tcp_conn_wait_idle(struct cifsd_tcp_conn *conn)
+{
+	wait_event(conn->req_running_q, atomic_read(&conn->req_running) < 2);
+}
+
 static void tcp_destroy_socket(void)
 {
 	int ret;

--- a/transport.c
+++ b/transport.c
@@ -530,6 +530,20 @@ int cifsd_tcp_write(struct smb_work *work)
 	return 0;
 }
 
+void cifsd_tcp_conn_lock(struct cifsd_tcp_conn *conn)
+{
+	mutex_lock(&conn->srv_mutex);
+	atomic_inc(&conn->req_running);
+}
+
+void cifsd_tcp_conn_unlock(struct cifsd_tcp_conn *conn)
+{
+	atomic_dec(&conn->req_running);
+	mutex_unlock(&conn->srv_mutex);
+	if (waitqueue_active(&conn->req_running_q))
+		wake_up_all(&conn->req_running_q);
+}
+
 static void tcp_destroy_socket(void)
 {
 	int ret;

--- a/transport.h
+++ b/transport.h
@@ -145,6 +145,7 @@ struct cifsd_tcp_conn {
 
 void cifsd_tcp_conn_lock(struct cifsd_tcp_conn *conn);
 void cifsd_tcp_conn_unlock(struct cifsd_tcp_conn *conn);
+void cifsd_tcp_conn_wait_idle(struct cifsd_tcp_conn *conn);
 
 int cifsd_tcp_read(struct cifsd_tcp_conn *conn,
 		   char *buf,

--- a/transport.h
+++ b/transport.h
@@ -143,6 +143,9 @@ struct cifsd_tcp_conn {
 	struct cifsd_tcp_conn_ops	*conn_ops;
 };
 
+void cifsd_tcp_conn_lock(struct cifsd_tcp_conn *conn);
+void cifsd_tcp_conn_unlock(struct cifsd_tcp_conn *conn);
+
 int cifsd_tcp_read(struct cifsd_tcp_conn *conn,
 		   char *buf,
 		   unsigned int to_read);


### PR DESCRIPTION
The patch set adds a simple tcp_conn API extension to address some of
common mistakes, e.g. missing ->req_runing decrement.
