### PR TITLE
cifsd: rename smb_work

### DIFF
--- a/buffer_pool.c
+++ b/buffer_pool.c
@@ -108,12 +108,12 @@ void *cifsd_realloc_response(void *ptr, size_t old_sz, size_t new_sz)
 	return nptr;
 }
 
-struct smb_work *cifsd_alloc_work_struct(void)
+struct cifsd_work *cifsd_alloc_work_struct(void)
 {
 	return kmem_cache_zalloc(work_cache, GFP_KERNEL);
 }
 
-void cifsd_free_work_struct(struct smb_work *work)
+void cifsd_free_work_struct(struct cifsd_work *work)
 {
 	cifsd_free_response(RESPONSE_BUF(work));
 	cifsd_free_response(AUX_PAYLOAD(work));
@@ -140,7 +140,7 @@ void cifsd_destroy_buffer_pools(void)
 int cifsd_init_buffer_pools(void)
 {
 	work_cache = kmem_cache_create("cifsd_work_cache",
-					sizeof(struct smb_work), 0,
+					sizeof(struct cifsd_work), 0,
 					SLAB_HWCACHE_ALIGN, NULL);
 	if (work_cache == NULL)
 		goto out;

--- a/buffer_pool.h
+++ b/buffer_pool.h
@@ -19,7 +19,7 @@
 #ifndef __CIFSD_BUFFER_POOL_H__
 #define __CIFSD_BUFFER_POOL_H__
 
-struct smb_work;
+struct cifsd_work;
 
 void *cifsd_alloc(size_t size);
 void cifsd_free(void *ptr);
@@ -31,8 +31,8 @@ void *cifsd_alloc_response(size_t size);
 
 void *cifsd_realloc_response(void *ptr, size_t old_sz, size_t new_sz);
 
-struct smb_work *cifsd_alloc_work_struct(void);
-void cifsd_free_work_struct(struct smb_work *work);
+struct cifsd_work *cifsd_alloc_work_struct(void);
+void cifsd_free_work_struct(struct cifsd_work *work);
 
 void cifsd_free_file_struct(void *filp);
 void *cifsd_alloc_file_struct(void);

--- a/fh.h
+++ b/fh.h
@@ -87,7 +87,7 @@ struct smb_dirent {
 struct notification {
 	unsigned int mode;
 	struct list_head queuelist;
-	struct smb_work *work;
+	struct cifsd_work *work;
 };
 
 struct cifsd_lock {
@@ -100,7 +100,7 @@ struct cifsd_lock {
 	int zero_len;
 	unsigned long long start;
 	unsigned long long end;
-	struct smb_work *work;
+	struct cifsd_work *work;
 };
 
 struct stream {
@@ -239,7 +239,7 @@ void insert_mfp_hash(struct cifsd_mfile *mfp);
 void remove_mfp_hash(struct cifsd_mfile *mfp);
 struct cifsd_mfile *mfp_lookup(struct cifsd_file *fp);
 struct cifsd_mfile *mfp_lookup_inode(struct inode *inode);
-struct cifsd_file *get_fp(struct smb_work *smb_work, int64_t req_vid,
+struct cifsd_file *get_fp(struct cifsd_work *work, int64_t req_vid,
 	int64_t req_pid);
 struct cifsd_mfile *get_mfp(struct cifsd_file *fp);
 

--- a/misc.c
+++ b/misc.c
@@ -140,32 +140,32 @@ int check_smb_message(char *buf)
 /**
  * add_request_to_queue() - check a request for addition to pending smb work
  *				queue
- * @smb_work:	smb request work
+ * @cifsd_work:	smb request work
  *
  * Return:      true if not add to queue, otherwise false
  */
-void add_request_to_queue(struct smb_work *smb_work)
+void add_request_to_queue(struct cifsd_work *work)
 {
-	struct cifsd_tcp_conn *conn = smb_work->conn;
+	struct cifsd_tcp_conn *conn = work->conn;
 	struct list_head *requests_queue = NULL;
-	struct smb2_hdr *hdr = REQUEST_BUF(smb_work);
+	struct smb2_hdr *hdr = REQUEST_BUF(work);
 
 	if (*(__le32 *)hdr->ProtocolId == SMB2_PROTO_NUMBER) {
-		unsigned int command = conn->ops->get_cmd_val(smb_work);
+		unsigned int command = conn->ops->get_cmd_val(work);
 
 		if (command != SMB2_CANCEL) {
 			requests_queue = &conn->requests;
-			smb_work->type = SYNC;
+			work->type = SYNC;
 		}
 	} else {
-		if (conn->ops->get_cmd_val(smb_work) != SMB_COM_NT_CANCEL)
+		if (conn->ops->get_cmd_val(work) != SMB_COM_NT_CANCEL)
 			requests_queue = &conn->requests;
 	}
 
 	if (requests_queue) {
 		spin_lock(&conn->request_lock);
-		list_add_tail(&smb_work->request_entry, requests_queue);
-		smb_work->added_in_request_list = 1;
+		list_add_tail(&work->request_entry, requests_queue);
+		work->added_in_request_list = 1;
 		spin_unlock(&conn->request_lock);
 	}
 }
@@ -402,20 +402,20 @@ void init_smb2_1_server(struct cifsd_tcp_conn *server) { }
 void init_smb3_0_server(struct cifsd_tcp_conn *server) { }
 void init_smb3_02_server(struct cifsd_tcp_conn *server) { }
 void init_smb3_11_server(struct cifsd_tcp_conn *server) { }
-int is_smb2_neg_cmd(struct smb_work *smb_work)
+int is_smb2_neg_cmd(struct cifsd_work *work)
 {
 	return 0;
 }
 
-bool is_chained_smb2_message(struct smb_work *smb_work)
+bool is_chained_smb2_message(struct cifsd_work *work)
 {
 	return 0;
 }
 
-void init_smb2_neg_rsp(struct smb_work *smb_work)
+void init_smb2_neg_rsp(struct cifsd_work *work)
 {
 }
-int is_smb2_rsp(struct smb_work *smb_work)
+int is_smb2_rsp(struct cifsd_work *work)
 {
 	return 0;
 };

--- a/oplock.h
+++ b/oplock.h
@@ -70,7 +70,7 @@ struct lease {
 struct oplock_info {
 	struct cifsd_tcp_conn	*conn;
 	struct cifsd_sess	*sess;
-	struct smb_work		*work;
+	struct cifsd_work		*work;
 	bool			is_smb2;
 	struct cifsd_file	*o_fp;
 	int                     level;
@@ -107,12 +107,12 @@ struct oplock_break_info {
 	int fid;
 };
 
-extern int smb_grant_oplock(struct smb_work *work, int req_op_level,
+extern int smb_grant_oplock(struct cifsd_work *work, int req_op_level,
 		uint64_t id, struct cifsd_file *fp, __u16 Tid,
 		struct lease_ctx_info *lctx, int share_ret);
-extern void smb1_send_oplock_break_notification(struct work_struct *work);
+extern void smb1_send_oplock_break_notification(struct work_struct *wk);
 #ifdef CONFIG_CIFS_SMB2_SERVER
-extern void smb2_send_oplock_break_notification(struct work_struct *work);
+extern void smb2_send_oplock_break_notification(struct work_struct *wk);
 #endif
 extern void smb_break_all_levII_oplock(struct cifsd_tcp_conn *conn,
 	struct cifsd_file *fp, int is_trunc);
@@ -122,7 +122,7 @@ int opinfo_read_handle_to_read(struct oplock_info *opinfo);
 int opinfo_write_to_none(struct oplock_info *opinfo);
 int opinfo_read_to_none(struct oplock_info *opinfo);
 void close_id_del_oplock(struct cifsd_file *fp);
-void smb_break_all_oplock(struct smb_work *work, struct cifsd_file *fp);
+void smb_break_all_oplock(struct cifsd_work *work, struct cifsd_file *fp);
 
 #ifdef CONFIG_CIFS_SMB2_SERVER
 /* Lease related functions */

--- a/smb1pdu.h
+++ b/smb1pdu.h
@@ -1489,12 +1489,12 @@ typedef struct {
 	__le16  InformationLevel;
 } __attribute__((packed)) TRANSACTION2_QFI_REQ_PARAMS;
 
-extern int set_path_info(struct smb_work *smb_work);
-extern int set_fs_info(struct smb_work *smb_work);
-extern int query_file_info(struct smb_work *smb_work);
-extern int set_file_info(struct smb_work *smb_work);
-extern int create_dir(struct smb_work *smb_work);
-extern int get_dfs_referral(struct smb_work *smb_work);
+extern int set_path_info(struct cifsd_work *work);
+extern int set_fs_info(struct cifsd_work *work);
+extern int query_file_info(struct cifsd_work *work);
+extern int set_file_info(struct cifsd_work *work);
+extern int create_dir(struct cifsd_work *work);
+extern int get_dfs_referral(struct cifsd_work *work);
 
 /* FIND FIRST2 and FIND NEXT2 INFOMATION Level Codes*/
 
@@ -1952,47 +1952,47 @@ typedef struct smb_com_setattr_rsp {
 } __attribute__((packed)) SETATTR_RSP;
 
 /* function prototypes */
-extern int init_smb_rsp_hdr(struct smb_work *swork);
-extern int get_smb_cmd_val(struct smb_work *smb_work);
-extern void set_smb_rsp_status(struct smb_work *smb_work, unsigned int err);
-extern int init_smb_rsp_hdr(struct smb_work *smb_work);
-extern int smb_allocate_rsp_buf(struct smb_work *smb_work);
+extern int init_smb_rsp_hdr(struct cifsd_work *swork);
+extern int get_smb_cmd_val(struct cifsd_work *work);
+extern void set_smb_rsp_status(struct cifsd_work *work, unsigned int err);
+extern int init_smb_rsp_hdr(struct cifsd_work *work);
+extern int smb_allocate_rsp_buf(struct cifsd_work *work);
 extern int find_matching_smb1_dialect(int start_index, char *cli_dialects,
 	__le16 byte_count);
-extern int smb1_is_sign_req(struct smb_work *work, unsigned int command);
-extern int smb1_check_sign_req(struct smb_work *work);
-extern void smb1_set_sign_rsp(struct smb_work *work);
-extern int smb_check_user_session(struct smb_work *smb_work);
-extern int smb_get_cifsd_tcon(struct smb_work *smb_work);
+extern int smb1_is_sign_req(struct cifsd_work *work, unsigned int command);
+extern int smb1_check_sign_req(struct cifsd_work *work);
+extern void smb1_set_sign_rsp(struct cifsd_work *work);
+extern int smb_check_user_session(struct cifsd_work *work);
+extern int smb_get_cifsd_tcon(struct cifsd_work *work);
 
 /* smb1 command handlers */
-extern int smb_rename(struct smb_work *smb_work);
-extern int smb_negotiate(struct smb_work *smb_work);
-extern int smb_session_setup_andx(struct smb_work *smb_work);
-extern int smb_tree_connect_andx(struct smb_work *smb_work);
-extern int smb_trans2(struct smb_work *smb_work);
-extern int smb_nt_create_andx(struct smb_work *smb_work);
-extern int smb_trans(struct smb_work *smb_work);
-extern int smb_locking_andx(struct smb_work *smb_work);
-extern int smb_close(struct smb_work *smb_work);
-extern int smb_read_andx(struct smb_work *smb_work);
-extern int smb_tree_disconnect(struct smb_work *smb_work);
-extern int smb_session_disconnect(struct smb_work *smb_work);
-extern int smb_write_andx(struct smb_work *smb_work);
-extern int smb_echo(struct smb_work *smb_work);
-extern int smb_flush(struct smb_work *smb_work);
-extern int smb_mkdir(struct smb_work *smb_work);
-extern int smb_rmdir(struct smb_work *smb_work);
-extern int smb_unlink(struct smb_work *smb_work);
-extern int smb_nt_cancel(struct smb_work *smb_work);
-extern int smb_nt_rename(struct smb_work *smb_work);
-extern int smb_creat_hardlink(struct smb_work *smb_work);
-extern int smb_creat_symlink(struct smb_work *smb_work);
-extern int smb_query_info(struct smb_work *smb_work);
-extern int smb_closedir(struct smb_work *smb_work);
-extern int smb_open_andx(struct smb_work *smb_work);
-extern int smb_write(struct smb_work *smb_work);
-extern int smb_setattr(struct smb_work *smb_work);
-extern int smb_checkdir(struct smb_work *smb_work);
-extern int smb_process_exit(struct smb_work *smb_work);
+extern int smb_rename(struct cifsd_work *work);
+extern int smb_negotiate(struct cifsd_work *work);
+extern int smb_session_setup_andx(struct cifsd_work *work);
+extern int smb_tree_connect_andx(struct cifsd_work *work);
+extern int smb_trans2(struct cifsd_work *work);
+extern int smb_nt_create_andx(struct cifsd_work *work);
+extern int smb_trans(struct cifsd_work *work);
+extern int smb_locking_andx(struct cifsd_work *work);
+extern int smb_close(struct cifsd_work *work);
+extern int smb_read_andx(struct cifsd_work *work);
+extern int smb_tree_disconnect(struct cifsd_work *work);
+extern int smb_session_disconnect(struct cifsd_work *work);
+extern int smb_write_andx(struct cifsd_work *work);
+extern int smb_echo(struct cifsd_work *work);
+extern int smb_flush(struct cifsd_work *work);
+extern int smb_mkdir(struct cifsd_work *work);
+extern int smb_rmdir(struct cifsd_work *work);
+extern int smb_unlink(struct cifsd_work *work);
+extern int smb_nt_cancel(struct cifsd_work *work);
+extern int smb_nt_rename(struct cifsd_work *work);
+extern int smb_creat_hardlink(struct cifsd_work *work);
+extern int smb_creat_symlink(struct cifsd_work *work);
+extern int smb_query_info(struct cifsd_work *work);
+extern int smb_closedir(struct cifsd_work *work);
+extern int smb_open_andx(struct cifsd_work *work);
+extern int smb_write(struct cifsd_work *work);
+extern int smb_setattr(struct cifsd_work *work);
+extern int smb_checkdir(struct cifsd_work *work);
+extern int smb_process_exit(struct cifsd_work *work);
 #endif /* __CIFSD_SMB1PDU_H */

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -1344,48 +1344,48 @@ struct create_ea_buf_req {
 } __packed;
 
 /* functions */
-extern int get_smb2_cmd_val(struct smb_work *smb_work);
-extern void set_smb2_rsp_status(struct smb_work *smb_work, unsigned int err);
-extern int init_smb2_rsp_hdr(struct smb_work *smb_work);
-extern int smb2_allocate_rsp_buf(struct smb_work *smb_work);
-extern bool is_chained_smb2_message(struct smb_work *smb_work);
-extern void init_smb2_neg_rsp(struct smb_work *smb_work);
-extern void smb2_set_rsp_credits(struct smb_work *smb_work);
-extern void smb2_set_err_rsp(struct smb_work *smb_work);
-extern int smb2_check_user_session(struct smb_work *smb_work);
-extern int smb2_get_cifsd_tcon(struct smb_work *smb_work);
-extern int smb2_is_sign_req(struct smb_work *work, unsigned int command);
-extern int smb2_check_sign_req(struct smb_work *work);
-extern void smb2_set_sign_rsp(struct smb_work *work);
-extern int smb3_check_sign_req(struct smb_work *work);
-extern void smb3_set_sign_rsp(struct smb_work *work);
+extern int get_smb2_cmd_val(struct cifsd_work *work);
+extern void set_smb2_rsp_status(struct cifsd_work *work, unsigned int err);
+extern int init_smb2_rsp_hdr(struct cifsd_work *work);
+extern int smb2_allocate_rsp_buf(struct cifsd_work *work);
+extern bool is_chained_smb2_message(struct cifsd_work *work);
+extern void init_smb2_neg_rsp(struct cifsd_work *work);
+extern void smb2_set_rsp_credits(struct cifsd_work *work);
+extern void smb2_set_err_rsp(struct cifsd_work *work);
+extern int smb2_check_user_session(struct cifsd_work *work);
+extern int smb2_get_cifsd_tcon(struct cifsd_work *work);
+extern int smb2_is_sign_req(struct cifsd_work *work, unsigned int command);
+extern int smb2_check_sign_req(struct cifsd_work *work);
+extern void smb2_set_sign_rsp(struct cifsd_work *work);
+extern int smb3_check_sign_req(struct cifsd_work *work);
+extern void smb3_set_sign_rsp(struct cifsd_work *work);
 extern int find_matching_smb2_dialect(int start_index, __le16 *cli_dialects,
 	__le16 dialects_count);
 extern struct file_lock *smb_flock_init(struct file *f);
-extern void smb2_send_interim_resp(struct smb_work *smb_work);
+extern void smb2_send_interim_resp(struct cifsd_work *work);
 
 /* smb2 command handlers */
 extern int calc_preauth_integrity_hash(struct cifsd_tcp_conn *conn,
 	char *buf, __u8 *pi_hash);
-extern int smb2_negotiate(struct smb_work *smb_work);
-extern int smb2_sess_setup(struct smb_work *smb_work);
-extern int smb2_tree_connect(struct smb_work *smb_work);
-extern int smb2_tree_disconnect(struct smb_work *smb_work);
-extern int smb2_session_logoff(struct smb_work *smb_work);
-extern int smb2_open(struct smb_work *smb_work);
-extern int smb2_query_info(struct smb_work *smb_work);
-extern int smb2_query_dir(struct smb_work *smb_work);
-extern int smb2_close(struct smb_work *smb_work);
-extern int smb2_close(struct smb_work *smb_work);
-extern int smb2_echo(struct smb_work *smb_work);
-extern int smb2_set_info(struct smb_work *smb_work);
-extern int smb2_read(struct smb_work *smb_work);
-extern int smb2_write(struct smb_work *smb_work);
-extern int smb2_flush(struct smb_work *smb_work);
-extern int smb2_cancel(struct smb_work *smb_work);
-extern int smb2_lock(struct smb_work *smb_work);
-extern int smb2_ioctl(struct smb_work *smb_work);
-extern int smb2_oplock_break(struct smb_work *smb_work);
-extern int smb2_notify(struct smb_work *smb_work);
+extern int smb2_negotiate(struct cifsd_work *work);
+extern int smb2_sess_setup(struct cifsd_work *work);
+extern int smb2_tree_connect(struct cifsd_work *work);
+extern int smb2_tree_disconnect(struct cifsd_work *work);
+extern int smb2_session_logoff(struct cifsd_work *work);
+extern int smb2_open(struct cifsd_work *work);
+extern int smb2_query_info(struct cifsd_work *work);
+extern int smb2_query_dir(struct cifsd_work *work);
+extern int smb2_close(struct cifsd_work *work);
+extern int smb2_close(struct cifsd_work *work);
+extern int smb2_echo(struct cifsd_work *work);
+extern int smb2_set_info(struct cifsd_work *work);
+extern int smb2_read(struct cifsd_work *work);
+extern int smb2_write(struct cifsd_work *work);
+extern int smb2_flush(struct cifsd_work *work);
+extern int smb2_cancel(struct cifsd_work *work);
+extern int smb2_lock(struct cifsd_work *work);
+extern int smb2_ioctl(struct cifsd_work *work);
+extern int smb2_oplock_break(struct cifsd_work *work);
+extern int smb2_notify(struct cifsd_work *work);
 
 #endif				/* _SMB2PDU_SERVER_H */

--- a/transport.c
+++ b/transport.c
@@ -472,14 +472,14 @@ int cifsd_tcp_read(struct cifsd_tcp_conn *conn,
 
 /**
  * cifsd_tcp_write() - send smb response over network socket
- * @smb_work:     smb work containing response buffer
+ * @cifsd_work:     smb work containing response buffer
  *
  * TODO: change this function for smb2 currently is working for
  * smb1/smb2 both as smb*_buf_length is at beginning of the  packet
  *
  * Return:	0 on success, otherwise error
  */
-int cifsd_tcp_write(struct smb_work *work)
+int cifsd_tcp_write(struct cifsd_work *work)
 {
 	struct cifsd_tcp_conn *conn = work->conn;
 	struct smb_hdr *rsp_hdr = RESPONSE_BUF(work);

--- a/transport.h
+++ b/transport.h
@@ -150,8 +150,8 @@ void cifsd_tcp_conn_wait_idle(struct cifsd_tcp_conn *conn);
 int cifsd_tcp_read(struct cifsd_tcp_conn *conn,
 		   char *buf,
 		   unsigned int to_read);
-struct smb_work;
-int cifsd_tcp_write(struct smb_work *work);
+struct cifsd_work;
+int cifsd_tcp_write(struct cifsd_work *work);
 
 void cifsd_tcp_init_server_callbacks(struct cifsd_tcp_conn_ops *ops);
 
@@ -164,42 +164,42 @@ int cifsd_tcp_init(void);
  * This is a hack. We will move status to a proper place once we land
  * a multi-sessions support.
  */
-static inline bool cifsd_tcp_good(struct smb_work *work)
+static inline bool cifsd_tcp_good(struct cifsd_work *work)
 {
 	return work->conn->tcp_status == CIFSD_SESS_GOOD;
 }
 
-static inline bool cifsd_tcp_need_negotiate(struct smb_work *work)
+static inline bool cifsd_tcp_need_negotiate(struct cifsd_work *work)
 {
 	return work->conn->tcp_status == CIFSD_SESS_NEED_NEGOTIATE;
 }
 
-static inline bool cifsd_tcp_need_reconnect(struct smb_work *work)
+static inline bool cifsd_tcp_need_reconnect(struct cifsd_work *work)
 {
 	return work->conn->tcp_status == CIFSD_SESS_NEED_RECONNECT;
 }
 
-static inline bool cifsd_tcp_exiting(struct smb_work *work)
+static inline bool cifsd_tcp_exiting(struct cifsd_work *work)
 {
 	return work->conn->tcp_status == CIFSD_SESS_EXITING;
 }
 
-static inline void cifsd_tcp_set_good(struct smb_work *work)
+static inline void cifsd_tcp_set_good(struct cifsd_work *work)
 {
 	work->conn->tcp_status = CIFSD_SESS_GOOD;
 }
 
-static inline void cifsd_tcp_set_need_negotiate(struct smb_work *work)
+static inline void cifsd_tcp_set_need_negotiate(struct cifsd_work *work)
 {
 	work->conn->tcp_status = CIFSD_SESS_NEED_NEGOTIATE;
 }
 
-static inline void cifsd_tcp_set_need_reconnect(struct smb_work *work)
+static inline void cifsd_tcp_set_need_reconnect(struct cifsd_work *work)
 {
 	work->conn->tcp_status = CIFSD_SESS_NEED_RECONNECT;
 }
 
-static inline void cifsd_tcp_set_exiting(struct smb_work *work)
+static inline void cifsd_tcp_set_exiting(struct cifsd_work *work)
 {
 	work->conn->tcp_status = CIFSD_SESS_EXITING;
 }

--- a/vfs.c
+++ b/vfs.c
@@ -129,7 +129,7 @@ static int smb_vfs_stream_read(struct cifsd_file *fp, char *buf, loff_t *pos,
  *
  * Return:	number of read bytes on success, otherwise error
  */
-int smb_vfs_read(struct smb_work *work,
+int smb_vfs_read(struct cifsd_work *work,
 		 struct cifsd_file *fp,
 		 size_t count,
 		 loff_t *pos)


### PR DESCRIPTION
Rename struct smb_work to cifsd_work.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>