### PR TITLE
VFS cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ cifsd-y := 	export.o unicode.o encrypt.o auth.o \
 		netlink.o cifsacl.o \
 		management/user.o\
 		buffer_pool.o \
-		transport.o \
+		transport_tcp.o \
 		server.o
 
 cifsd-$(CONFIG_CIFS_SMB2_SERVER) += smb2pdu.o smb2ops.o asn1.o

--- a/asn1.c
+++ b/asn1.c
@@ -26,7 +26,7 @@
 #include "glob.h"
 #include "export.h"
 
-#include "transport.h"
+#include "transport_tcp.h"
 
 /*****************************************************************************
  *

--- a/auth.c
+++ b/auth.c
@@ -29,7 +29,7 @@
 #include "glob.h"
 #include "export.h"
 
-#include "transport.h"
+#include "transport_tcp.h"
 
 /* Fixed format data defining GSS header and fixed string
  * "not_defined_in_RFC4178@please_ignore".

--- a/export.c
+++ b/export.c
@@ -26,7 +26,7 @@
 #include "export.h"
 #include "smb1pdu.h"
 
-#include "transport.h"
+#include "transport_tcp.h"
 
 /* max string size for share and parameters */
 #define SHARE_MAX_NAME_LEN	100

--- a/fh.c
+++ b/fh.c
@@ -27,7 +27,7 @@
 #include "smb1pdu.h"
 #include "oplock.h"
 #include "buffer_pool.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 /**
  * alloc_fid_mem() - alloc memory for fid management

--- a/fh.h
+++ b/fh.h
@@ -122,7 +122,7 @@ struct cifsd_file {
 	struct timespec open_time;
 	bool islink;
 	/* if ls is happening on directory, below is valid*/
-	struct smb_readdir_data	readdir_data;
+	struct cifsd_readdir_data	readdir_data;
 	int	dot_dotdot[2];
 	int	dirent_offset;
 	/* oplock info */

--- a/fh.h
+++ b/fh.h
@@ -28,6 +28,7 @@
 
 #include "glob.h"
 #include "netlink.h"
+#include "vfs.h"
 
 /* Windows style file permissions for extended response */
 #define	FILE_GENERIC_ALL	0x1F01FF
@@ -66,23 +67,6 @@
 
 struct cifsd_tcp_conn;
 struct cifsd_sess;
-
-struct smb_readdir_data {
-	struct dir_context ctx;
-	char           *dirent;
-	unsigned int   used;
-	unsigned int   full;
-	unsigned int   dirent_count;
-	unsigned int   file_attr;
-};
-
-struct smb_dirent {
-	__le64         ino;
-	__le64          offset;
-	__le32         namelen;
-	__le32         d_type;
-	char            name[];
-};
 
 struct notification {
 	unsigned int mode;
@@ -223,7 +207,6 @@ void free_fidtable(struct fidtable *ftab);
 struct cifsd_file *
 get_id_from_fidtable(struct cifsd_sess *sess, uint64_t id);
 int close_id(struct cifsd_sess *sess, uint64_t id, uint64_t p_id);
-bool is_dir_empty(struct cifsd_file *fp);
 unsigned int get_pipe_type(char *pipename);
 int cifsd_get_unused_id(struct fidtable_desc *ftab_desc);
 int cifsd_close_id(struct fidtable_desc *ftab_desc, int id);

--- a/glob.h
+++ b/glob.h
@@ -550,9 +550,6 @@ int smb_filldir(struct dir_context *ctx, const char *name, int namlen,
 		loff_t offset, u64 ino, unsigned int d_type);
 int smb_get_shortname(struct cifsd_tcp_conn *conn, char *longname,
 		char *shortname);
-void *fill_common_info(char **p, struct smb_kstat *smb_kstat);
-char *read_next_entry(struct cifsd_work *work, struct smb_kstat *smb_kstat,
-		struct smb_dirent *de, char *dirpath);
 /* fill SMB specific fields when smb2 query dir is requested */
 char *convname_updatenextoffset(char *namestr, int len, int size,
 		const struct nls_table *local_nls, int *name_len,

--- a/glob.h
+++ b/glob.h
@@ -416,19 +416,6 @@ struct cifsd_dir_info {
 	int last_entry_offset;
 };
 
-/* cifsd kstat wrapper to get valid create time when reading dir entry */
-struct smb_kstat {
-	struct kstat *kstat;
-	__u64 create_time;
-	__le32 file_attributes;
-};
-
-struct smb2_fs_sector_size {
-	unsigned short logical_sector_size;
-	unsigned int physical_sector_size;
-	unsigned int optimal_io_size;
-};
-
 struct cifsd_pid_info {
 	struct socket *socket;
 	__u32 cifsd_pid;
@@ -526,51 +513,6 @@ extern int parse_stream_name(char *filename, char **stream_name, int *s_type);
 extern int construct_xattr_stream_name(char *stream_name,
 	char **xattr_stream_name);
 extern char *convert_to_nt_pathname(char *filename, char *sharepath);
-
-/* smb vfs functions */
-int smb_vfs_create(const char *name, umode_t mode);
-int smb_vfs_mkdir(const char *name, umode_t mode);
-int smb_vfs_read(struct cifsd_work *work, struct cifsd_file *fp,
-		 size_t count, loff_t *pos);
-int smb_vfs_write(struct cifsd_sess *sess, struct cifsd_file *fp,
-	char *buf, size_t count, loff_t *pos, bool fsync, ssize_t *written);
-int smb_vfs_getattr(struct cifsd_sess *sess, uint64_t fid,
-		struct kstat *stat);
-int smb_vfs_setattr(struct cifsd_sess *sess, const char *name,
-		uint64_t fid, struct iattr *attrs);
-int smb_vfs_fsync(struct cifsd_sess *sess, uint64_t fid, uint64_t p_id);
-struct cifsd_file *smb_dentry_open(struct cifsd_work *work,
-	const struct path *path, int flags, int option, int fexist);
-int smb_vfs_remove_file(char *name);
-int smb_vfs_link(const char *oldname, const char *newname);
-int smb_vfs_symlink(const char *name, const char *symname);
-int smb_vfs_readlink(struct path *path, char *buf, int len);
-int smb_vfs_rename(char *abs_oldname, char *abs_newname, struct cifsd_file *fp);
-int smb_vfs_truncate(struct cifsd_sess *sess, const char *name,
-	struct cifsd_file *fp, loff_t size);
-ssize_t smb_vfs_listxattr(struct dentry *dentry, char **list, int size);
-ssize_t smb_vfs_getxattr(struct dentry *dentry, char *xattr_name,
-		char **xattr_buf, int flags);
-int smb_vfs_setxattr(const char *filename, struct path *path, const char *name,
-		const void *value, size_t size, int flags);
-int smb_kern_path(char *name, unsigned int flags, struct path *path,
-		bool caseless);
-int smb_search_dir(char *dirname, char *filename);
-void smb_vfs_set_fadvise(struct file *filp, int option);
-int smb_vfs_lock(struct file *filp, int cmd, struct file_lock *flock);
-int check_lock_range(struct file *filp, loff_t start,
-		loff_t end, unsigned char type);
-int smb_vfs_readdir(struct file *file, filldir_t filler,
-			struct smb_readdir_data *buf);
-int smb_vfs_alloc_size(struct cifsd_tcp_conn *conn, struct cifsd_file *fp,
-	loff_t len);
-int smb_vfs_truncate_xattr(struct dentry *dentry);
-int smb_vfs_truncate_stream_xattr(struct dentry *dentry);
-int smb_vfs_remove_xattr(struct path *path, char *field_name);
-int smb_vfs_unlink(struct dentry *dir, struct dentry *dentry);
-unsigned short get_logical_sector_size(struct inode *inode);
-void get_smb2_sector_size(struct inode *inode,
-	struct smb2_fs_sector_size *fs_ss);
 
 /* smb1ops functions */
 extern void init_smb1_server(struct cifsd_tcp_conn *conn);

--- a/glob.h
+++ b/glob.h
@@ -555,11 +555,13 @@ char *convname_updatenextoffset(char *namestr, int len, int size,
 		const struct nls_table *local_nls, int *name_len,
 		int *next_entry_offset, int *buf_len, int *data_count,
 		int alignment, bool no_namelen_field);
+
+struct cifsd_kstat;
 int smb_populate_dot_dotdot_entries(struct cifsd_tcp_conn *conn,
 		int info_level, struct cifsd_file *dir,
 		struct cifsd_dir_info *d_info, char *search_pattern,
 		int (*populate_readdir_entry_fn)(struct cifsd_tcp_conn *,
-		int, struct cifsd_dir_info *, struct smb_kstat *));
+		int, struct cifsd_dir_info *, struct cifsd_kstat *));
 
 /* netlink functions */
 int cifsd_net_init(void);

--- a/misc.c
+++ b/misc.c
@@ -29,6 +29,7 @@
 #include "smb1pdu.h"
 #include "smb2pdu.h"
 #include "transport_tcp.h"
+#include "vfs.h"
 
 static struct {
 	int index;
@@ -427,7 +428,7 @@ int smb_store_cont_xattr(struct path *path, char *prefix, void *value,
 {
 	int err;
 
-	err = smb_vfs_setxattr(NULL, path, prefix, value, v_len, 0);
+	err = cifsd_vfs_setxattr(NULL, path, prefix, value, v_len, 0);
 	if (err)
 		cifsd_debug("setxattr failed, err %d\n", err);
 
@@ -440,7 +441,7 @@ ssize_t smb_find_cont_xattr(struct path *path, char *prefix, int p_len,
 	char *name, *xattr_list = NULL;
 	ssize_t value_len = -ENOENT, xattr_list_len;
 
-	xattr_list_len = smb_vfs_listxattr(path->dentry, &xattr_list,
+	xattr_list_len = cifsd_vfs_listxattr(path->dentry, &xattr_list,
 		XATTR_LIST_MAX);
 	if (xattr_list_len < 0) {
 		goto out;
@@ -455,7 +456,7 @@ ssize_t smb_find_cont_xattr(struct path *path, char *prefix, int p_len,
 		if (strncasecmp(prefix, name, p_len))
 			continue;
 
-		value_len = smb_vfs_getxattr(path->dentry, name, value, flags);
+		value_len = cifsd_vfs_getxattr(path->dentry, name, value, flags);
 		if (value_len < 0)
 			cifsd_err("failed to get xattr in file\n");
 		break;
@@ -601,7 +602,7 @@ int smb_check_shared_mode(struct file *filp, struct cifsd_file *curr_fp)
 
 	if (!same_stream && !curr_fp->is_stream) {
 		if (curr_fp->cdoption == FILE_SUPERSEDE_LE) {
-			smb_vfs_truncate_stream_xattr(
+			cifsd_vfs_truncate_stream_xattr(
 				curr_fp->filp->f_path.dentry);
 		}
 	}

--- a/misc.c
+++ b/misc.c
@@ -28,7 +28,7 @@
 #include "export.h"
 #include "smb1pdu.h"
 #include "smb2pdu.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 static struct {
 	int index;

--- a/netlink.c
+++ b/netlink.c
@@ -26,7 +26,7 @@
 #include "glob.h"
 #include "export.h"
 #include "netlink.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 #define NETLINK_CIFSD			31
 #define NETLINK_RRQ_RECV_TIMEOUT	10000

--- a/oplock.c
+++ b/oplock.c
@@ -28,7 +28,7 @@
 #include "oplock.h"
 
 #include "buffer_pool.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 bool oplocks_enable = true;
 #ifdef CONFIG_CIFS_SMB2_SERVER

--- a/server.c
+++ b/server.c
@@ -30,7 +30,7 @@
 #endif
 
 #include "buffer_pool.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 bool global_signing;
 

--- a/smb1ops.c
+++ b/smb1ops.c
@@ -23,7 +23,7 @@
 #include "glob.h"
 #include "smb1pdu.h"
 
-#include "transport.h"
+#include "transport_tcp.h"
 
 struct smb_version_values smb1_server_values = {
 	.version_string = SMB1_VERSION_STRING,

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -27,7 +27,7 @@
 #include "smb1pdu.h"
 #include "oplock.h"
 #include "buffer_pool.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 /*for shortname implementation */
 static const char basechars[43] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-!@#$%";

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -6157,7 +6157,7 @@ static int find_first(struct cifsd_work *work)
 	TRANSACTION2_FFIRST_REQ_PARAMS *req_params;
 	T2_FFIRST_RSP_PARMS *params = NULL;
 	struct path path;
-	struct smb_dirent *de;
+	struct cifsd_dirent *de;
 	struct cifsd_file *dir_fp = NULL;
 	struct kstat kstat;
 	struct smb_kstat smb_kstat;
@@ -6263,15 +6263,15 @@ static int find_first(struct cifsd_work *work)
 				break;
 			}
 
-			de = (struct smb_dirent *)
+			de = (struct cifsd_dirent *)
 				((char *)dir_fp->readdir_data.dirent);
 		} else {
-			de = (struct smb_dirent *)
+			de = (struct cifsd_dirent *)
 				((char *)dir_fp->readdir_data.dirent +
 				 dir_fp->dirent_offset);
 		}
 
-		reclen = ALIGN(sizeof(struct smb_dirent) + de->namelen,
+		reclen = ALIGN(sizeof(struct cifsd_dirent) + de->namelen,
 				sizeof(__le64));
 		dir_fp->dirent_offset += reclen;
 
@@ -6401,7 +6401,7 @@ static int find_next(struct cifsd_work *work)
 	TRANSACTION2_RSP *rsp = (TRANSACTION2_RSP *)RESPONSE_BUF(work);
 	TRANSACTION2_FNEXT_REQ_PARAMS *req_params;
 	T2_FNEXT_RSP_PARMS *params = NULL;
-	struct smb_dirent *de;
+	struct cifsd_dirent *de;
 	struct cifsd_file *dir_fp;
 	struct kstat kstat;
 	struct smb_kstat smb_kstat;
@@ -6489,15 +6489,15 @@ static int find_next(struct cifsd_work *work)
 				break;
 			}
 
-			de = (struct smb_dirent *)
+			de = (struct cifsd_dirent *)
 				((char *)dir_fp->readdir_data.dirent);
 		} else {
-			de = (struct smb_dirent *)
+			de = (struct cifsd_dirent *)
 				((char *)dir_fp->readdir_data.dirent +
 				 dir_fp->dirent_offset);
 		}
 
-		reclen = ALIGN(sizeof(struct smb_dirent) + de->namelen,
+		reclen = ALIGN(sizeof(struct cifsd_dirent) + de->namelen,
 				sizeof(__le64));
 		dir_fp->dirent_offset += reclen;
 
@@ -7621,10 +7621,10 @@ int smb_filldir(struct dir_context *ctx, const char *name, int namlen,
 {
 	struct cifsd_readdir_data *buf =
 		container_of(ctx, struct cifsd_readdir_data, ctx);
-	struct smb_dirent *de = (void *)(buf->dirent + buf->used);
+	struct cifsd_dirent *de = (void *)(buf->dirent + buf->used);
 	unsigned int reclen;
 
-	reclen = ALIGN(sizeof(struct smb_dirent) + namlen, sizeof(u64));
+	reclen = ALIGN(sizeof(struct cifsd_dirent) + namlen, sizeof(u64));
 	if (buf->used + reclen > PAGE_SIZE) {
 		buf->full = 1;
 		return -EINVAL;

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -6168,7 +6168,7 @@ static int find_first(struct cifsd_work *work)
 	int srch_cnt = 0;
 	char *dirpath = NULL;
 	char *srch_ptr = NULL;
-	struct smb_readdir_data r_data = {
+	struct cifsd_readdir_data r_data = {
 		.ctx.actor = smb_filldir,
 		.dirent = (void *)__get_free_page(GFP_KERNEL)
 	};
@@ -6413,7 +6413,7 @@ static int find_next(struct cifsd_work *work)
 	char *dirpath = NULL;
 	char *name = NULL;
 	char *pathname = NULL;
-	struct smb_readdir_data r_data = {
+	struct cifsd_readdir_data r_data = {
 		.ctx.actor = smb_filldir,
 	};
 	int header_size;
@@ -7619,8 +7619,8 @@ int smb_trans2(struct cifsd_work *work)
 int smb_filldir(struct dir_context *ctx, const char *name, int namlen,
 		loff_t offset, u64 ino, unsigned int d_type)
 {
-	struct smb_readdir_data *buf =
-		container_of(ctx, struct smb_readdir_data, ctx);
+	struct cifsd_readdir_data *buf =
+		container_of(ctx, struct cifsd_readdir_data, ctx);
 	struct smb_dirent *de = (void *)(buf->dirent + buf->used);
 	unsigned int reclen;
 

--- a/smb2ops.c
+++ b/smb2ops.c
@@ -24,7 +24,7 @@
 #include "export.h"
 #include "smb2pdu.h"
 
-#include "transport.h"
+#include "transport_tcp.h"
 
 struct smb_version_values smb20_server_values = {
 	.version_string = SMB20_VERSION_STRING,

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -3075,7 +3075,7 @@ static int smb2_populate_readdir_entry(struct cifsd_tcp_conn *conn,
 			break;
 
 		ffdinfo = (FILE_FULL_DIRECTORY_INFO *)
-				fill_common_info(&d_info->bufptr, smb_kstat);
+				cifsd_vfs_init_kstat(&d_info->bufptr, smb_kstat);
 		ffdinfo->FileNameLength = cpu_to_le32(name_len);
 		ffdinfo->EaSize = 0;
 
@@ -3094,7 +3094,7 @@ static int smb2_populate_readdir_entry(struct cifsd_tcp_conn *conn,
 		if (!utfname)
 			break;
 		fbdinfo = (FILE_BOTH_DIRECTORY_INFO *)
-				fill_common_info(&d_info->bufptr, smb_kstat);
+				cifsd_vfs_init_kstat(&d_info->bufptr, smb_kstat);
 		fbdinfo->FileNameLength = cpu_to_le32(name_len);
 		fbdinfo->EaSize = 0;
 		fbdinfo->ShortNameLength = smb_get_shortname(conn, d_info->name,
@@ -3117,7 +3117,7 @@ static int smb2_populate_readdir_entry(struct cifsd_tcp_conn *conn,
 			break;
 
 		fdinfo = (FILE_DIRECTORY_INFO *)
-				fill_common_info(&d_info->bufptr, smb_kstat);
+				cifsd_vfs_init_kstat(&d_info->bufptr, smb_kstat);
 		fdinfo->FileNameLength = cpu_to_le32(name_len);
 
 		memcpy(fdinfo->FileName, utfname, name_len);
@@ -3136,7 +3136,7 @@ static int smb2_populate_readdir_entry(struct cifsd_tcp_conn *conn,
 			break;
 
 		fninfo = (FILE_NAMES_INFO *)
-				fill_common_info(&d_info->bufptr, smb_kstat);
+				cifsd_vfs_init_kstat(&d_info->bufptr, smb_kstat);
 		fninfo->FileNameLength = cpu_to_le32(name_len);
 
 		memcpy(fninfo->FileName, utfname, name_len);
@@ -3155,7 +3155,7 @@ static int smb2_populate_readdir_entry(struct cifsd_tcp_conn *conn,
 			break;
 
 		dinfo = (SEARCH_ID_FULL_DIR_INFO *)
-				fill_common_info(&d_info->bufptr, smb_kstat);
+				cifsd_vfs_init_kstat(&d_info->bufptr, smb_kstat);
 		dinfo->FileNameLength = cpu_to_le32(name_len);
 		dinfo->EaSize = 0;
 		dinfo->Reserved = 0;
@@ -3177,7 +3177,7 @@ static int smb2_populate_readdir_entry(struct cifsd_tcp_conn *conn,
 			break;
 
 		fibdinfo = (FILE_ID_BOTH_DIRECTORY_INFO *)
-				fill_common_info(&d_info->bufptr, smb_kstat);
+				cifsd_vfs_init_kstat(&d_info->bufptr, smb_kstat);
 		fibdinfo->FileNameLength = cpu_to_le32(name_len);
 		fibdinfo->EaSize = 0;
 		fibdinfo->UniqueId = cpu_to_le64(smb_kstat->kstat->ino);
@@ -3402,7 +3402,7 @@ int smb2_query_dir(struct cifsd_work *work)
 		dir_fp->dirent_offset += reclen;
 
 		smb_kstat.kstat = &kstat;
-		d_info.name = read_next_entry(work, &smb_kstat, de,
+		d_info.name = cifsd_vfs_readdir_name(work, &smb_kstat, de,
 			dirpath);
 		if (IS_ERR(d_info.name)) {
 			rc = PTR_ERR(d_info.name);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -31,7 +31,7 @@
 #include "cifsacl.h"
 
 #include "buffer_pool.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 bool multi_channel_enable;
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -3232,7 +3232,7 @@ int smb2_query_dir(struct cifsd_work *work)
 	struct smb_kstat smb_kstat;
 	char *dirpath, *srch_ptr = NULL, *path = NULL;
 	unsigned char srch_flag;
-	struct smb_readdir_data r_data = {
+	struct cifsd_readdir_data r_data = {
 		.ctx.actor = smb_filldir,
 	};
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -3223,7 +3223,7 @@ int smb2_query_dir(struct cifsd_work *work)
 	struct smb2_query_directory_req *req;
 	struct smb2_query_directory_rsp *rsp, *rsp_org;
 	struct cifsd_share *share = work->tcon->share;
-	struct smb_dirent *de;
+	struct cifsd_dirent *de;
 	struct cifsd_file *dir_fp;
 	struct cifsd_dir_info d_info;
 	int reclen = 0;
@@ -3389,15 +3389,15 @@ int smb2_query_dir(struct cifsd_work *work)
 				break;
 			}
 
-			de = (struct smb_dirent *)
+			de = (struct cifsd_dirent *)
 				((char *)dir_fp->readdir_data.dirent);
 		} else {
-			de = (struct smb_dirent *)
+			de = (struct cifsd_dirent *)
 				((char *)dir_fp->readdir_data.dirent +
 				 dir_fp->dirent_offset);
 		}
 
-		reclen = ALIGN(sizeof(struct smb_dirent) + de->namelen,
+		reclen = ALIGN(sizeof(struct cifsd_dirent) + de->namelen,
 				sizeof(__le64));
 		dir_fp->dirent_offset += reclen;
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -32,6 +32,7 @@
 
 #include "buffer_pool.h"
 #include "transport_tcp.h"
+#include "vfs.h"
 
 bool multi_channel_enable;
 
@@ -2080,7 +2081,7 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 
 			/* delete the EA only when it exits */
 			if (rc > 0) {
-				rc = smb_vfs_remove_xattr(path, attr_name);
+				rc = cifsd_vfs_remove_xattr(path, attr_name);
 
 				if (rc < 0) {
 					cifsd_err("remove xattr failed(%d)\n",
@@ -2092,11 +2093,11 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 			/* if the EA doesn't exist, just do nothing. */
 			rc = 0;
 		} else {
-			rc = smb_vfs_setxattr(NULL, path, attr_name, value,
+			rc = cifsd_vfs_setxattr(NULL, path, attr_name, value,
 				le16_to_cpu(eabuf->EaValueLength), 0);
 
 			if (rc < 0) {
-				cifsd_err("smb_vfs_setxattr is failed(%d)\n",
+				cifsd_err("cifsd_vfs_setxattr is failed(%d)\n",
 					rc);
 				break;
 			}
@@ -2377,15 +2378,15 @@ int smb2_open(struct cifsd_work *work)
 		 * On delete request, instead of following up, need to
 		 * look the current entity
 		 */
-		rc = smb_kern_path(name, 0, &path, 1);
+		rc = cifsd_vfs_kern_path(name, 0, &path, 1);
 	} else {
 		/*
 		* Use LOOKUP_FOLLOW to follow the path of
 		* symlink in path buildup
 		*/
-		rc = smb_kern_path(name, LOOKUP_FOLLOW, &path, 1);
+		rc = cifsd_vfs_kern_path(name, LOOKUP_FOLLOW, &path, 1);
 		if (rc) { /* Case for broken link ?*/
-			rc = smb_kern_path(name, 0, &path, 1);
+			rc = cifsd_vfs_kern_path(name, 0, &path, 1);
 		}
 	}
 
@@ -2461,7 +2462,7 @@ int smb2_open(struct cifsd_work *work)
 			if (req->CreateOptions & FILE_DIRECTORY_FILE_LE) {
 				cifsd_debug("creating directory\n");
 				mode = 00777 & ~current_umask();
-				rc = smb_vfs_mkdir(name, mode);
+				rc = cifsd_vfs_mkdir(name, mode);
 				if (rc) {
 					rsp->hdr.Status = cpu_to_le32(
 							NT_STATUS_DATA_ERROR);
@@ -2473,7 +2474,7 @@ int smb2_open(struct cifsd_work *work)
 			} else {
 				cifsd_debug("creating regular file\n");
 				mode = 00666 & ~current_umask();
-				rc = smb_vfs_create(name, mode);
+				rc = cifsd_vfs_create(name, mode);
 				if (rc) {
 					rsp->hdr.Status =
 						NT_STATUS_UNEXPECTED_IO_ERROR;
@@ -2482,7 +2483,7 @@ int smb2_open(struct cifsd_work *work)
 				}
 			}
 
-			rc = smb_kern_path(name, 0, &path, 0);
+			rc = cifsd_vfs_kern_path(name, 0, &path, 0);
 			if (rc) {
 				cifsd_err("cannot get linux path (%s), err = %d\n",
 						name, rc);
@@ -2547,7 +2548,7 @@ int smb2_open(struct cifsd_work *work)
 		islink = true;
 		cifsd_debug("Case for symlink follow, name(%s)->path(%s)\n",
 				name, lname);
-		rc = smb_kern_path(name, 0, &lpath, 0);
+		rc = cifsd_vfs_kern_path(name, 0, &lpath, 0);
 		if (rc) {
 			cifsd_err("cannot get linux path (%s), err = %d\n",
 				name, rc);
@@ -2579,7 +2580,7 @@ int smb2_open(struct cifsd_work *work)
 	} else if (open_flags & O_CREAT)
 		file_info = FILE_CREATED;
 
-	smb_vfs_set_fadvise(filp, le32_to_cpu(req->CreateOptions));
+	cifsd_vfs_set_fadvise(filp, le32_to_cpu(req->CreateOptions));
 
 	/* Obtain Volatile-ID */
 	volatile_id = cifsd_get_unused_id(&sess->fidtable);
@@ -2665,9 +2666,9 @@ int smb2_open(struct cifsd_work *work)
 
 			cifsd_debug("request smb2 create allocate size : %llu\n",
 				alloc_size);
-			rc = smb_vfs_alloc_size(conn, fp, alloc_size);
+			rc = cifsd_vfs_alloc_size(conn, fp, alloc_size);
 			if (rc < 0)
-				cifsd_debug("smb_vfs_alloc_size is failed : %d\n",
+				cifsd_debug("cifsd_vfs_alloc_size is failed : %d\n",
 					rc);
 		}
 
@@ -2742,9 +2743,9 @@ int smb2_open(struct cifsd_work *work)
 		 * FILE_SUPERSEDE
 		 */
 		if (req->CreateDisposition & FILE_SUPERSEDE_LE) {
-			rc = smb_vfs_truncate_xattr(path.dentry);
+			rc = cifsd_vfs_truncate_xattr(path.dentry);
 			if (rc) {
-				cifsd_err("smb_vfs_truncate_xattr is failed, rc %d\n",
+				cifsd_err("cifsd_vfs_truncate_xattr is failed, rc %d\n",
 					rc);
 				goto err_out;
 			}
@@ -3372,7 +3373,7 @@ int smb2_query_dir(struct cifsd_work *work)
 			dir_fp->dirent_offset = 0;
 			r_data.used = 0;
 			r_data.full = 0;
-			rc = smb_vfs_readdir(dir_fp->filp, smb_filldir,
+			rc = cifsd_vfs_readdir(dir_fp->filp, smb_filldir,
 					&r_data);
 			if (rc < 0) {
 				cifsd_debug("err : %d\n", rc);
@@ -3611,7 +3612,7 @@ static int smb2_get_ea(struct cifsd_tcp_conn *conn, struct path *path,
 	if (le32_to_cpu(req->OutputBufferLength) < buf_free_len)
 		buf_free_len = le32_to_cpu(req->OutputBufferLength);
 
-	rc = smb_vfs_listxattr(path->dentry, &xattr_list, XATTR_LIST_MAX);
+	rc = cifsd_vfs_listxattr(path->dentry, &xattr_list, XATTR_LIST_MAX);
 	if (rc < 0) {
 		rsp->hdr.Status = NT_STATUS_INVALID_HANDLE;
 		goto out;
@@ -3661,7 +3662,7 @@ static int smb2_get_ea(struct cifsd_tcp_conn *conn, struct path *path,
 		buf_free_len -= (offsetof(struct smb2_ea_info, name) +
 				name_len + 1);
 		/* bailout if xattr can't fit in buf_free_len */
-		value_len = smb_vfs_getxattr(path->dentry, name, &buf, 1);
+		value_len = cifsd_vfs_getxattr(path->dentry, name, &buf, 1);
 		if (value_len <= 0) {
 			rc = -ENOENT;
 			rsp->hdr.Status = NT_STATUS_INVALID_HANDLE;
@@ -3930,7 +3931,7 @@ static int smb2_get_info_file(struct cifsd_work *work,
 
 		file_info = (struct smb2_file_stream_info *)rsp->Buffer;
 
-		xattr_list_len = smb_vfs_listxattr(path->dentry, &xattr_list,
+		xattr_list_len = cifsd_vfs_listxattr(path->dentry, &xattr_list,
 				XATTR_LIST_MAX);
 		if (xattr_list_len < 0) {
 			goto out;
@@ -4187,7 +4188,7 @@ static int smb2_get_info_filesystem(struct cifsd_sess *sess,
 	if (!share)
 		return -ENOENT;
 
-	rc = smb_kern_path(share->path, LOOKUP_FOLLOW, &path, 0);
+	rc = cifsd_vfs_kern_path(share->path, LOOKUP_FOLLOW, &path, 0);
 	if (rc) {
 		cifsd_err("cannot create vfs path\n");
 		return -EIO;
@@ -4267,7 +4268,7 @@ static int smb2_get_info_filesystem(struct cifsd_sess *sess,
 
 			fs_size_info = (FILE_SYSTEM_INFO *)(rsp->Buffer);
 			logical_sector_size =
-				get_logical_sector_size(path.dentry->d_inode);
+				cifsd_vfs_logical_sector_size(path.dentry->d_inode);
 
 			fs_size_info->TotalAllocationUnits =
 						cpu_to_le64(stfs.f_blocks);
@@ -4290,7 +4291,7 @@ static int smb2_get_info_filesystem(struct cifsd_sess *sess,
 			fs_fullsize_info =
 				(struct smb2_fs_full_size_info *)(rsp->Buffer);
 			logical_sector_size =
-				get_logical_sector_size(path.dentry->d_inode);
+				cifsd_vfs_logical_sector_size(path.dentry->d_inode);
 
 			fs_fullsize_info->TotalAllocationUnits =
 						cpu_to_le64(stfs.f_blocks);
@@ -4338,7 +4339,7 @@ static int smb2_get_info_filesystem(struct cifsd_sess *sess,
 			struct smb2_fs_sector_size fs_ss;
 
 			ss_info = (struct smb3_fs_ss_info *)(rsp->Buffer);
-			get_smb2_sector_size(path.dentry->d_inode, &fs_ss);
+			cifsd_vfs_smb2_sector_size(path.dentry->d_inode, &fs_ss);
 
 			ss_info->LogicalBytesPerSector =
 				cpu_to_le32(fs_ss.logical_sector_size);
@@ -4867,7 +4868,7 @@ static int smb2_rename(struct cifsd_file *fp,
 	strncpy(tmp_name, new_name, PATH_MAX);
 	tmp_name[PATH_MAX - 1] = 0x00;
 	cifsd_debug("new name %s\n", new_name);
-	rc = smb_kern_path(tmp_name, 0, &path, 1);
+	rc = cifsd_vfs_kern_path(tmp_name, 0, &path, 1);
 	if (rc)
 		file_present = false;
 	else
@@ -4882,7 +4883,7 @@ static int smb2_rename(struct cifsd_file *fp,
 
 	if (file_info->ReplaceIfExists) {
 		if (file_present) {
-			rc = smb_vfs_remove_file(tmp_name);
+			rc = cifsd_vfs_remove_file(tmp_name);
 			if (rc) {
 				if (rc != -ENOTEMPTY)
 					rc = -EINVAL;
@@ -4901,7 +4902,7 @@ static int smb2_rename(struct cifsd_file *fp,
 		}
 	}
 
-	rc = smb_vfs_rename(NULL, new_name, fp);
+	rc = cifsd_vfs_rename(NULL, new_name, fp);
 out:
 	kfree(pathname);
 	kfree(tmp_name);
@@ -4947,7 +4948,7 @@ static int smb2_create_link(struct smb2_file_link_info *file_info,
 	}
 
 	cifsd_debug("target name is %s\n", target_name);
-	rc = smb_kern_path(link_name, 0, &path, 0);
+	rc = cifsd_vfs_kern_path(link_name, 0, &path, 0);
 	if (rc)
 		file_present = false;
 	else
@@ -4955,7 +4956,7 @@ static int smb2_create_link(struct smb2_file_link_info *file_info,
 
 	if (file_info->ReplaceIfExists) {
 		if (file_present) {
-			rc = smb_vfs_remove_file(link_name);
+			rc = cifsd_vfs_remove_file(link_name);
 			if (rc) {
 				rc = -EINVAL;
 				cifsd_debug("cannot delete %s\n",
@@ -4971,7 +4972,7 @@ static int smb2_create_link(struct smb2_file_link_info *file_info,
 		}
 	}
 
-	rc = smb_vfs_link(target_name, link_name);
+	rc = cifsd_vfs_link(target_name, link_name);
 	if (rc)
 		rc = -EINVAL;
 out:
@@ -5136,19 +5137,19 @@ static int smb2_set_info_file(struct cifsd_sess *sess, struct cifsd_file *fp,
 
 		file_alloc_info = (struct smb2_file_alloc_info *)buffer;
 		alloc_blks = le64_to_cpu(file_alloc_info->AllocationSize) >> 9;
-		logical_sector_size = get_logical_sector_size(inode);
+		logical_sector_size = cifsd_vfs_logical_sector_size(inode);
 
 		if (alloc_blks > inode->i_blocks) {
-			rc = smb_vfs_alloc_size(sess->conn, fp,
+			rc = cifsd_vfs_alloc_size(sess->conn, fp,
 				alloc_blks * logical_sector_size);
 
 			if (rc) {
-				cifsd_err("smb_vfs_alloc_size is failed : %d\n",
+				cifsd_err("cifsd_vfs_alloc_size is failed : %d\n",
 					rc);
 				return rc;
 			}
 		} else {
-			rc = smb_vfs_truncate(sess, NULL, fp,
+			rc = cifsd_vfs_truncate(sess, NULL, fp,
 				alloc_blks * logical_sector_size);
 
 			if (rc) {
@@ -5179,7 +5180,7 @@ static int smb2_set_info_file(struct cifsd_sess *sess, struct cifsd_file *fp,
 		newsize = le64_to_cpu(file_eof_info->EndOfFile);
 
 		if (newsize != i_size_read(inode)) {
-			rc = smb_vfs_truncate(sess, NULL, fp, newsize);
+			rc = cifsd_vfs_truncate(sess, NULL, fp, newsize);
 			if (rc) {
 				cifsd_err("truncate failed! filename : %s err %d\n",
 						fp->filename, rc);
@@ -5243,7 +5244,7 @@ next:
 
 		file_info = (struct smb2_file_disposition_info *)buffer;
 		if (file_info->DeletePending) {
-			if (S_ISDIR(inode->i_mode) && !is_dir_empty(fp))
+			if (S_ISDIR(inode->i_mode) && !cifsd_vfs_empty_dir(fp))
 				rc = -EBUSY;
 			else
 				fp->f_ci->m_flags |= S_DEL_PENDING;
@@ -5273,7 +5274,7 @@ next:
 
 		file_info = (struct smb2_file_pos_info *)buffer;
 		current_byte_offset = le64_to_cpu(file_info->CurrentByteOffset);
-		sector_size = get_logical_sector_size(inode);
+		sector_size = cifsd_vfs_logical_sector_size(inode);
 
 		if (current_byte_offset < 0 ||
 			(fp->coption == FILE_NO_INTERMEDIATE_BUFFERING_LE &&
@@ -5308,7 +5309,7 @@ next:
 		 * TODO : need to implement consideration for
 		 * FILE_SYNCHRONOUS_IO_ALERT and FILE_SYNCHRONOUS_IO_NONALERT
 		 */
-		smb_vfs_set_fadvise(fp->filp, le32_to_cpu(mode));
+		cifsd_vfs_set_fadvise(fp->filp, le32_to_cpu(mode));
 		fp->coption = mode;
 
 		break;
@@ -5542,7 +5543,7 @@ int smb2_read(struct cifsd_work *work)
 		goto out;
 	}
 
-	nbytes = smb_vfs_read(work, fp, length, &offset);
+	nbytes = cifsd_vfs_read(work, fp, length, &offset);
 	if (nbytes < 0) {
 		err = nbytes;
 		goto out;
@@ -5752,7 +5753,7 @@ int smb2_write(struct cifsd_work *work)
 
 	cifsd_debug("filename %s, offset %lld, len %zu\n", FP_FILENAME(fp),
 		offset, length);
-	err = smb_vfs_write(work->sess, fp, data_buf, length, &offset,
+	err = cifsd_vfs_write(work->sess, fp, data_buf, length, &offset,
 			writethrough, &nbytes);
 	if (err < 0)
 		goto out;
@@ -5808,7 +5809,7 @@ int smb2_flush(struct cifsd_work *work)
 	cifsd_debug("SMB2_FLUSH called for fid %llu\n",
 			le64_to_cpu(req->VolatileFileId));
 
-	err = smb_vfs_fsync(work->sess,
+	err = cifsd_vfs_fsync(work->sess,
 		le64_to_cpu(req->VolatileFileId),
 		le64_to_cpu(req->PersistentFileId));
 	if (err)
@@ -6187,7 +6188,7 @@ no_check_gl:
 		flock = smb_lock->fl;
 		list_del(&smb_lock->llist);
 retry:
-		err = smb_vfs_lock(filp, smb_lock->cmd, flock);
+		err = cifsd_vfs_lock(filp, smb_lock->cmd, flock);
 skip:
 		if (flags & SMB2_LOCKFLAG_UNLOCK) {
 			if (!err)
@@ -6288,7 +6289,7 @@ out:
 		rlock->fl_start = smb_lock->start;
 		rlock->fl_end = smb_lock->end;
 
-		err = smb_vfs_lock(filp, 0, rlock);
+		err = cifsd_vfs_lock(filp, 0, rlock);
 		if (err)
 			cifsd_err("rollback unlock fail : %d\n", err);
 		list_del(&smb_lock->llist);

--- a/transport_tcp.c
+++ b/transport_tcp.c
@@ -23,7 +23,7 @@
 #include "export.h"
 
 #include "buffer_pool.h"
-#include "transport.h"
+#include "transport_tcp.h"
 
 static struct task_struct *cifsd_kthread;
 static struct socket *cifsd_socket = NULL;

--- a/transport_tcp.h
+++ b/transport_tcp.h
@@ -16,8 +16,8 @@
  *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
  */
 
-#ifndef __CIFSD_TRANSPORT_H__
-#define __CIFSD_TRANSPORT_H__
+#ifndef __CIFSD_TRANSPORT_TCP_H__
+#define __CIFSD_TRANSPORT_TCP_H__
 
 #include <linux/list.h>
 #include <linux/ip.h>
@@ -202,4 +202,4 @@ static inline void cifsd_tcp_set_exiting(struct cifsd_work *work)
 {
 	work->conn->tcp_status = CIFSD_SESS_EXITING;
 }
-#endif /* __CIFSD_TRANSPORT_H__ */
+#endif /* __CIFSD_TRANSPORT_TCP_H__ */

--- a/vfs.c
+++ b/vfs.c
@@ -1187,7 +1187,7 @@ out:
 }
 
 int cifsd_vfs_readdir(struct file *file, filldir_t filler,
-			struct smb_readdir_data *rdata)
+			struct cifsd_readdir_data *rdata)
 {
 	return iterate_dir(file, &rdata->ctx);
 }
@@ -1381,7 +1381,7 @@ bool cifsd_vfs_empty_dir(struct cifsd_file *fp)
 {
 	struct path dir_path;
 	struct file *filp;
-	struct smb_readdir_data r_data = {
+	struct cifsd_readdir_data r_data = {
 		.ctx.actor = smb_filldir,
 		.dirent = (void *)__get_free_page(GFP_KERNEL),
 		.dirent_count = 0
@@ -1476,7 +1476,7 @@ int cifsd_vfs_lookup_in_dir(char *dirname, char *filename)
 	int namelen = strlen(filename);
 	int dirnamelen = strlen(dirname);
 	bool match_found = false;
-	struct smb_readdir_data readdir_data = {
+	struct cifsd_readdir_data readdir_data = {
 		.ctx.actor = smb_filldir,
 		.dirent = (void *)__get_free_page(GFP_KERNEL)
 	};

--- a/vfs.c
+++ b/vfs.c
@@ -1531,3 +1531,153 @@ out:
 	dirname[dirnamelen] = '/';
 	return ret;
 }
+
+/**
+ * fill_create_time() - fill create time of directory entry in smb_kstat
+ * if related config is not yes, create time is same with change time
+ *
+ * @work: smb work containing share config
+ * @path: path info
+ * @smb_kstat: cifsd kstat wrapper
+ */
+static void fill_create_time(struct cifsd_work *work,
+	struct path *path, struct smb_kstat *smb_kstat)
+{
+	char *create_time = NULL;
+	int xattr_len;
+
+	/*
+	 * if "store dos attributes" conf is not yes,
+	 * create time = change time
+	 */
+	smb_kstat->create_time = cifs_UnixTimeToNT(smb_kstat->kstat->ctime);
+
+	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
+		xattr_len = smb_find_cont_xattr(path,
+			XATTR_NAME_CREATION_TIME,
+			XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
+
+		if (xattr_len > 0)
+			smb_kstat->create_time = *((u64 *)create_time);
+
+		cifsd_free(create_time);
+	}
+}
+
+/**
+ * cifsd_vfs_init_kstat() - convert unix stat information to smb stat format
+ * @p:          destination buffer
+ * @smb_kstat:      cifsd kstat wrapper
+ */
+void *cifsd_vfs_init_kstat(char **p, struct smb_kstat *smb_kstat)
+{
+	FILE_DIRECTORY_INFO *info = (FILE_DIRECTORY_INFO *)(*p);
+	info->FileIndex = 0;
+	info->CreationTime = cpu_to_le64(smb_kstat->create_time);
+	info->LastAccessTime = cpu_to_le64(
+			cifs_UnixTimeToNT(smb_kstat->kstat->atime));
+	info->LastWriteTime = cpu_to_le64(
+			cifs_UnixTimeToNT(smb_kstat->kstat->mtime));
+	info->ChangeTime = cpu_to_le64(
+			cifs_UnixTimeToNT(smb_kstat->kstat->ctime));
+	if (smb_kstat->file_attributes & ATTR_DIRECTORY) {
+		info->EndOfFile = 0;
+		info->AllocationSize = 0;
+	} else {
+		info->EndOfFile = cpu_to_le64(smb_kstat->kstat->size);
+		info->AllocationSize =
+			cpu_to_le64(smb_kstat->kstat->blocks << 9);
+	}
+	info->ExtFileAttributes = cpu_to_le32(smb_kstat->file_attributes);
+
+	return info;
+}
+
+/*
+ * fill_file_attributes() - fill FileAttributes of directory entry in smb_kstat.
+ * if related config is not yes, just fill 0x10(dir) or 0x80(regular file).
+ *
+ * @work: smb work containing share config
+ * @path: path info
+ * @smb_kstat: cifsd kstat wrapper
+ */
+
+static void fill_file_attributes(struct cifsd_work *work,
+	struct path *path, struct smb_kstat *smb_kstat)
+{
+	/*
+	 * set default value for the case that store dos attributes is not yes
+	 * or that acl is disable in server's filesystem and the config is yes.
+	 */
+	if (S_ISDIR(smb_kstat->kstat->mode))
+		smb_kstat->file_attributes = ATTR_DIRECTORY;
+	else
+		smb_kstat->file_attributes = ATTR_ARCHIVE;
+
+	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
+		char *file_attribute = NULL;
+		int rc;
+
+		rc = smb_find_cont_xattr(path,
+			XATTR_NAME_FILE_ATTRIBUTE,
+			XATTR_NAME_FILE_ATTRIBUTE_LEN, &file_attribute, 1);
+
+		if (rc > 0)
+			smb_kstat->file_attributes =
+				*((__le32 *)file_attribute);
+		else
+			cifsd_debug("fail to fill file attributes.\n");
+
+		cifsd_free(file_attribute);
+	}
+}
+
+/**
+ * read_next_entry() - read next directory entry and return absolute name
+ * @work:	smb work containing share config
+ * @smb_kstat:	cifsd wrapper of next dirent's stat
+ * @de:		directory entry
+ * @dirpath:	directory path name
+ *
+ * Return:      on success return absolute path of directory entry,
+ *              otherwise NULL
+ */
+char *cifsd_vfs_readdir_name(struct cifsd_work *work,
+			     struct smb_kstat *smb_kstat,
+			     struct smb_dirent *de,
+			     char *dirpath)
+{
+	struct path path;
+	int rc, file_pathlen, dir_pathlen;
+	char *name;
+
+	dir_pathlen = strlen(dirpath);
+	/* 1 for '/'*/
+	file_pathlen = dir_pathlen +  de->namelen + 1;
+	name = kmalloc(file_pathlen + 1, GFP_KERNEL);
+	if (!name) {
+		cifsd_err("Name memory failed for length %d,"
+				" buf_name_len %d\n", dir_pathlen, de->namelen);
+		return ERR_PTR(-ENOMEM);
+	}
+
+	memcpy(name, dirpath, dir_pathlen);
+	memset(name + dir_pathlen, '/', 1);
+	memcpy(name + dir_pathlen + 1, de->name, de->namelen);
+	name[file_pathlen] = '\0';
+
+	rc = cifsd_vfs_kern_path(name, 0, &path, 1);
+	if (rc) {
+		cifsd_err("look up failed for (%s) with rc=%d\n", name, rc);
+		kfree(name);
+		return ERR_PTR(rc);
+	}
+
+	generic_fillattr(path.dentry->d_inode, smb_kstat->kstat);
+	fill_create_time(work, &path, smb_kstat);
+	fill_file_attributes(work, &path, smb_kstat);
+	memcpy(name, de->name, de->namelen);
+	name[de->namelen] = '\0';
+	path_put(&path);
+	return name;
+}

--- a/vfs.c
+++ b/vfs.c
@@ -33,7 +33,7 @@
 #include "export.h"
 #include "glob.h"
 #include "oplock.h"
-#include "transport.h"
+#include "transport_tcp.h"
 #include "buffer_pool.h"
 
 /**

--- a/vfs.c
+++ b/vfs.c
@@ -35,15 +35,16 @@
 #include "oplock.h"
 #include "transport_tcp.h"
 #include "buffer_pool.h"
+#include "vfs.h"
 
 /**
- * smb_vfs_create() - vfs helper for smb create file
+ * cifsd_vfs_create() - vfs helper for smb create file
  * @name:	file name
  * @mode:	file create mode
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_create(const char *name, umode_t mode)
+int cifsd_vfs_create(const char *name, umode_t mode)
 {
 	struct path path;
 	struct dentry *dentry;
@@ -67,13 +68,13 @@ int smb_vfs_create(const char *name, umode_t mode)
 }
 
 /**
- * smb_vfs_mkdir() - vfs helper for smb create directory
+ * cifsd_vfs_mkdir() - vfs helper for smb create directory
  * @name:	directory name
  * @mode:	directory create mode
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_mkdir(const char *name, umode_t mode)
+int cifsd_vfs_mkdir(const char *name, umode_t mode)
 {
 	struct path path;
 	struct dentry *dentry;
@@ -98,7 +99,7 @@ int smb_vfs_mkdir(const char *name, umode_t mode)
 	return err;
 }
 
-static int smb_vfs_stream_read(struct cifsd_file *fp, char *buf, loff_t *pos,
+static int cifsd_vfs_stream_read(struct cifsd_file *fp, char *buf, loff_t *pos,
 	size_t count)
 {
 	ssize_t v_len;
@@ -121,7 +122,7 @@ static int smb_vfs_stream_read(struct cifsd_file *fp, char *buf, loff_t *pos,
 }
 
 /**
- * smb_vfs_read() - vfs helper for smb file read
+ * cifsd_vfs_read() - vfs helper for smb file read
  * @work:	smb work
  * @fid:	file id of open file
  * @count:	read byte count
@@ -129,7 +130,7 @@ static int smb_vfs_stream_read(struct cifsd_file *fp, char *buf, loff_t *pos,
  *
  * Return:	number of read bytes on success, otherwise error
  */
-int smb_vfs_read(struct cifsd_work *work,
+int cifsd_vfs_read(struct cifsd_work *work,
 		 struct cifsd_file *fp,
 		 size_t count,
 		 loff_t *pos)
@@ -165,7 +166,7 @@ int smb_vfs_read(struct cifsd_work *work,
 #endif
 
 	if (fp->is_stream)
-		return smb_vfs_stream_read(fp, rbuf, pos, count);
+		return cifsd_vfs_stream_read(fp, rbuf, pos, count);
 
 	ret = check_lock_range(filp, *pos, *pos + count - 1,
 			READ);
@@ -197,7 +198,7 @@ int smb_vfs_read(struct cifsd_work *work,
 	return nbytes;
 }
 
-static int smb_vfs_stream_write(struct cifsd_file *fp, char *buf, loff_t *pos,
+static int cifsd_vfs_stream_write(struct cifsd_file *fp, char *buf, loff_t *pos,
 	size_t count)
 {
 	char *stream_buf = NULL, *wbuf;
@@ -248,7 +249,7 @@ out:
 }
 
 /**
- * smb_vfs_write() - vfs helper for smb file write
+ * cifsd_vfs_write() - vfs helper for smb file write
  * @sess:	session
  * @fid:	file id of open file
  * @buf:	buf containing data for writing
@@ -259,7 +260,7 @@ out:
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_write(struct cifsd_sess *sess, struct cifsd_file *fp,
+int cifsd_vfs_write(struct cifsd_sess *sess, struct cifsd_file *fp,
 	char *buf, size_t count, loff_t *pos, bool sync, ssize_t *written)
 {
 	struct file *filp;
@@ -284,7 +285,7 @@ int smb_vfs_write(struct cifsd_sess *sess, struct cifsd_file *fp,
 	filp = fp->filp;
 
 	if (fp->is_stream) {
-		err = smb_vfs_stream_write(fp, buf, pos, count);
+		err = cifsd_vfs_stream_write(fp, buf, pos, count);
 		if (!err)
 			*written = count;
 		goto out;
@@ -365,7 +366,7 @@ void smb_check_attrs(struct inode *inode, struct iattr *attrs)
 }
 
 /**
- * smb_vfs_setattr() - vfs helper for smb setattr
+ * cifsd_vfs_setattr() - vfs helper for smb setattr
  * @sess:	session
  * @name:	file name
  * @fid:	file id of open file
@@ -373,7 +374,7 @@ void smb_check_attrs(struct inode *inode, struct iattr *attrs)
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_setattr(struct cifsd_sess *sess, const char *name,
+int cifsd_vfs_setattr(struct cifsd_sess *sess, const char *name,
 		uint64_t fid, struct iattr *attrs)
 {
 	struct file *filp;
@@ -457,14 +458,14 @@ out:
 }
 
 /**
- * smb_vfs_getattr() - vfs helper for smb getattr
+ * cifsd_vfs_getattr() - vfs helper for smb getattr
  * @sess:	session
  * @fid:	file id of open file
  * @attrs:	inode attributes
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_getattr(struct cifsd_sess *sess, uint64_t fid,
+int cifsd_vfs_getattr(struct cifsd_sess *sess, uint64_t fid,
 		struct kstat *stat)
 {
 	struct file *filp;
@@ -490,13 +491,13 @@ int smb_vfs_getattr(struct cifsd_sess *sess, uint64_t fid,
 }
 
 /**
- * smb_vfs_fsync() - vfs helper for smb fsync
+ * cifsd_vfs_fsync() - vfs helper for smb fsync
  * @sess:	session
  * @fid:	file id of open file
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_fsync(struct cifsd_sess *sess, uint64_t fid, uint64_t p_id)
+int cifsd_vfs_fsync(struct cifsd_sess *sess, uint64_t fid, uint64_t p_id)
 {
 	struct cifsd_file *fp;
 	int err;
@@ -521,12 +522,12 @@ int smb_vfs_fsync(struct cifsd_sess *sess, uint64_t fid, uint64_t p_id)
 }
 
 /**
- * smb_vfs_remove_file() - vfs helper for smb rmdir or unlink
+ * cifsd_vfs_remove_file() - vfs helper for smb rmdir or unlink
  * @name:	absolute directory or file name
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_remove_file(char *name)
+int cifsd_vfs_remove_file(char *name)
 {
 	struct path parent;
 	struct dentry *dir, *dentry;
@@ -594,13 +595,13 @@ out:
 }
 
 /**
- * smb_vfs_link() - vfs helper for creating smb hardlink
+ * cifsd_vfs_link() - vfs helper for creating smb hardlink
  * @oldname:	source file name
  * @newname:	hardlink name
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_link(const char *oldname, const char *newname)
+int cifsd_vfs_link(const char *oldname, const char *newname)
 {
 	struct path oldpath, newpath;
 	struct dentry *dentry;
@@ -641,13 +642,13 @@ out1:
 }
 
 /**
- * smb_vfs_symlink() - vfs helper for creating smb symlink
+ * cifsd_vfs_symlink() - vfs helper for creating smb symlink
  * @name:	source file name
  * @symname:	symlink name
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_symlink(const char *name, const char *symname)
+int cifsd_vfs_symlink(const char *name, const char *symname)
 {
 	struct path path;
 	struct dentry *dentry;
@@ -670,14 +671,14 @@ int smb_vfs_symlink(const char *name, const char *symname)
 }
 
 /**
- * smb_vfs_readlink() - vfs helper for reading value of symlink
+ * cifsd_vfs_readlink() - vfs helper for reading value of symlink
  * @path:	path of symlink
  * @buf:	destination buffer for symlink value
  * @lenp:	destination buffer length
  *
  * Return:	symlink value length on success, otherwise error
  */
-int smb_vfs_readlink(struct path *path, char *buf, int lenp)
+int cifsd_vfs_readlink(struct path *path, char *buf, int lenp)
 {
 	struct inode *inode;
 	mm_segment_t old_fs;
@@ -701,7 +702,7 @@ int smb_vfs_readlink(struct path *path, char *buf, int lenp)
 }
 
 /**
- * smb_vfs_rename() - vfs helper for smb rename
+ * cifsd_vfs_rename() - vfs helper for smb rename
  * @sess:		session
  * @abs_oldname:	old filename
  * @abs_newname:	new filename
@@ -709,7 +710,7 @@ int smb_vfs_readlink(struct path *path, char *buf, int lenp)
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_rename(char *abs_oldname, char *abs_newname, struct cifsd_file *fp)
+int cifsd_vfs_rename(char *abs_oldname, char *abs_newname, struct cifsd_file *fp)
 {
 	struct path oldpath_p, newpath_p;
 	struct dentry *dold, *dnew, *dold_p, *dnew_p, *trap, *child_de;
@@ -851,7 +852,7 @@ out1:
 }
 
 /**
- * smb_vfs_truncate() - vfs helper for smb file truncate
+ * cifsd_vfs_truncate() - vfs helper for smb file truncate
  * @sess:	session
  * @name:	old filename
  * @fid:	file id of old file
@@ -859,7 +860,7 @@ out1:
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_truncate(struct cifsd_sess *sess, const char *name,
+int cifsd_vfs_truncate(struct cifsd_sess *sess, const char *name,
 	struct cifsd_file *fp, loff_t size)
 {
 	struct path path;
@@ -910,14 +911,14 @@ int smb_vfs_truncate(struct cifsd_sess *sess, const char *name,
 }
 
 /**
- * smb_vfs_listxattr() - vfs helper for smb list extended attributes
+ * cifsd_vfs_listxattr() - vfs helper for smb list extended attributes
  * @dentry:	dentry of file for listing xattrs
  * @list:	destination buffer
  * @size:	destination buffer length
  *
  * Return:	xattr list length on success, otherwise error
  */
-ssize_t smb_vfs_listxattr(struct dentry *dentry, char **list, int size)
+ssize_t cifsd_vfs_listxattr(struct dentry *dentry, char **list, int size)
 {
 	ssize_t err;
 	char *vlist = NULL;
@@ -943,7 +944,7 @@ ssize_t smb_vfs_listxattr(struct dentry *dentry, char **list, int size)
 }
 
 /**
- * smb_vfs_getxattr() - vfs helper for smb get extended attributes value
+ * cifsd_vfs_getxattr() - vfs helper for smb get extended attributes value
  * @dentry:	dentry of file for getting xattrs
  * @xattr_name:	name of xattr name to query
  * @xattr_buf:	destination buffer xattr value
@@ -951,7 +952,7 @@ ssize_t smb_vfs_listxattr(struct dentry *dentry, char **list, int size)
  *
  * Return:	read xattr value length on success, otherwise error
  */
-ssize_t smb_vfs_getxattr(struct dentry *dentry, char *xattr_name,
+ssize_t cifsd_vfs_getxattr(struct dentry *dentry, char *xattr_name,
 	char **xattr_buf, int flags)
 {
 	ssize_t xattr_len;
@@ -979,7 +980,7 @@ ssize_t smb_vfs_getxattr(struct dentry *dentry, char *xattr_name,
 }
 
 /**
- * smb_vfs_setxattr() - vfs helper for smb set extended attributes value
+ * cifsd_vfs_setxattr() - vfs helper for smb set extended attributes value
  * @filename:	file name
  * @fpath:	path of file for setxattr
  * @name:	xattr name for setxattr
@@ -989,7 +990,7 @@ ssize_t smb_vfs_getxattr(struct dentry *dentry, char *xattr_name,
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_setxattr(const char *filename, struct path *fpath, const char *name,
+int cifsd_vfs_setxattr(const char *filename, struct path *fpath, const char *name,
 		const void *value, size_t size, int flags)
 {
 	struct path path;
@@ -1015,13 +1016,13 @@ int smb_vfs_setxattr(const char *filename, struct path *fpath, const char *name,
 	return err;
 }
 
-int smb_vfs_truncate_xattr(struct dentry *dentry)
+int cifsd_vfs_truncate_xattr(struct dentry *dentry)
 {
 	char *name, *xattr_list = NULL;
 	ssize_t xattr_list_len;
 	int err = 0;
 
-	xattr_list_len = smb_vfs_listxattr(dentry, &xattr_list,
+	xattr_list_len = cifsd_vfs_listxattr(dentry, &xattr_list,
 		XATTR_LIST_MAX);
 	if (xattr_list_len < 0) {
 		goto out;
@@ -1049,13 +1050,13 @@ out:
 	return err;
 }
 
-int smb_vfs_truncate_stream_xattr(struct dentry *dentry)
+int cifsd_vfs_truncate_stream_xattr(struct dentry *dentry)
 {
 	char *name, *xattr_list = NULL;
 	ssize_t xattr_list_len;
 	int err = 0;
 
-	xattr_list_len = smb_vfs_listxattr(dentry, &xattr_list,
+	xattr_list_len = cifsd_vfs_listxattr(dentry, &xattr_list,
 		XATTR_LIST_MAX);
 	if (xattr_list_len < 0) {
 		goto out;
@@ -1084,11 +1085,11 @@ out:
 }
 
 /**
- * smb_vfs_set_fadvise() - convert smb IO caching options to linux options
+ * cifsd_vfs_set_fadvise() - convert smb IO caching options to linux options
  * @filp:	file pointer for IO
  * @options:	smb IO options
  */
-void smb_vfs_set_fadvise(struct file *filp, int option)
+void cifsd_vfs_set_fadvise(struct file *filp, int option)
 {
 	struct address_space *mapping;
 	mapping = filp->f_mapping;
@@ -1129,14 +1130,14 @@ void smb_vfs_set_fadvise(struct file *filp, int option)
 }
 
 /**
- * smb_vfs_lock() - vfs helper for smb file locking
+ * cifsd_vfs_lock() - vfs helper for smb file locking
  * @filp:	the file to apply the lock to
  * @cmd:	type of locking operation (F_SETLK, F_GETLK, etc.)
  * @flock:	The lock to be applied
  *
  * Return:	0 on success, otherwise error
  */
-int smb_vfs_lock(struct file *filp, int cmd,
+int cifsd_vfs_lock(struct file *filp, int cmd,
 			struct file_lock *flock)
 {
 	cifsd_debug("%s: calling vfs_lock_file\n", __func__);
@@ -1185,13 +1186,13 @@ out:
 	return error;
 }
 
-int smb_vfs_readdir(struct file *file, filldir_t filler,
+int cifsd_vfs_readdir(struct file *file, filldir_t filler,
 			struct smb_readdir_data *rdata)
 {
 	return iterate_dir(file, &rdata->ctx);
 }
 
-int smb_vfs_alloc_size(struct cifsd_tcp_conn *conn, struct cifsd_file *fp,
+int cifsd_vfs_alloc_size(struct cifsd_tcp_conn *conn, struct cifsd_file *fp,
 	loff_t len)
 {
 	if (oplocks_enable)
@@ -1199,12 +1200,12 @@ int smb_vfs_alloc_size(struct cifsd_tcp_conn *conn, struct cifsd_file *fp,
 	return vfs_fallocate(fp->filp, FALLOC_FL_KEEP_SIZE, 0, len);
 }
 
-int smb_vfs_remove_xattr(struct path *path, char *field_name)
+int cifsd_vfs_remove_xattr(struct path *path, char *field_name)
 {
 	return vfs_removexattr(path->dentry, field_name);
 }
 
-int smb_vfs_unlink(struct dentry *dir, struct dentry *dentry)
+int cifsd_vfs_unlink(struct dentry *dir, struct dentry *dentry)
 {
 	int err = 0;
 
@@ -1238,12 +1239,12 @@ out:
 }
 
 /*
- * get_logical_sector_size() - get logical sector size from inode
+ * cifsd_vfs_get_logical_sector_size() - get logical sector size from inode
  * @inode: inode
  *
  * Return: logical sector size
  */
-unsigned short get_logical_sector_size(struct inode *inode)
+unsigned short cifsd_vfs_logical_sector_size(struct inode *inode)
 {
 	struct request_queue *q;
 	unsigned short ret_val = 512;
@@ -1259,12 +1260,13 @@ unsigned short get_logical_sector_size(struct inode *inode)
 	return ret_val;
 }
 
+#ifdef CONFIG_CIFS_SMB2_SERVER
 /*
- * get_smb2_sector_size() - get fs sector sizes
+ * cifsd_vfs_get_smb2_sector_size() - get fs sector sizes
  * @inode: inode
  * @fs_ss: fs sector size struct
  */
-void get_smb2_sector_size(struct inode *inode,
+void cifsd_vfs_smb2_sector_size(struct inode *inode,
 	struct smb2_fs_sector_size *fs_ss)
 {
 	struct request_queue *q;
@@ -1284,4 +1286,248 @@ void get_smb2_sector_size(struct inode *inode,
 		if (q->limits.io_opt)
 			fs_ss->optimal_io_size = q->limits.io_opt;
 	}
+}
+#else
+void cifsd_vfs_get_smb2_sector_size(struct inode *inode,
+	struct smb2_fs_sector_size *fs_ss)
+{
+}
+#endif
+
+/**
+ * cifsd_vfs_dentry_open() - open a dentry and provide fid for it
+ * @work:	smb work ptr
+ * @path:	path of dentry to be opened
+ * @flags:	open flags
+ * @ret_id:	fid returned on this
+ * @option:	file access pattern options for fadvise
+ * @fexist:	file already present or not
+ *
+ * Return:	0 on success, otherwise error
+ */
+struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
+	const struct path *path, int flags, int option, int fexist)
+{
+	struct cifsd_sess *sess = work->sess;
+	struct file *filp;
+	int id, err = 0;
+	struct cifsd_file *fp = NULL;
+	uint64_t sess_id;
+	struct cifsd_inode *ci;
+
+	filp = dentry_open(path, flags | O_LARGEFILE, current_cred());
+	if (IS_ERR(filp)) {
+		err = PTR_ERR(filp);
+		cifsd_err("dentry open failed, err %d\n", err);
+		return ERR_PTR(err);
+	}
+
+	cifsd_vfs_set_fadvise(filp, option);
+
+	sess_id = sess == NULL ? 0 : sess->sess_id;
+	id = cifsd_get_unused_id(&sess->fidtable);
+	if (id < 0)
+		goto err_out3;
+
+	cifsd_debug("allocate volatile id : %d\n", id);
+	fp = insert_id_in_fidtable(sess, work->tcon, id, filp);
+	if (fp == NULL) {
+		err = -ENOMEM;
+		cifsd_err("id insert failed\n");
+		goto err_out2;
+	}
+
+	fp->f_ci = ci = cifsd_inode_get(fp);
+	if (!ci)
+		goto err_out1;
+
+	if (flags & O_TRUNC) {
+		if (oplocks_enable && fexist)
+			smb_break_all_oplock(work, fp);
+		err = vfs_truncate((struct path *)path, 0);
+		if (err)
+			goto err_out;
+	}
+
+	INIT_LIST_HEAD(&fp->lock_list);
+
+	return fp;
+
+err_out:
+	list_del(&fp->node);
+	if (ci && atomic_dec_and_test(&ci->m_count))
+		cifsd_inode_free(ci);
+err_out1:
+	delete_id_from_fidtable(sess, id);
+err_out2:
+	cifsd_close_id(&sess->fidtable, id);
+err_out3:
+	fput(filp);
+
+	if (err) {
+		fp = ERR_PTR(err);
+		cifsd_err("err : %d\n", err);
+	}
+	return fp;
+}
+
+/**
+ * cifsd_vfs_empty_dir() - check for empty directory
+ * @fp:	cifsd file pointer
+ *
+ * Return:	true if directory empty, otherwise false
+ */
+bool cifsd_vfs_empty_dir(struct cifsd_file *fp)
+{
+	struct path dir_path;
+	struct file *filp;
+	struct smb_readdir_data r_data = {
+		.ctx.actor = smb_filldir,
+		.dirent = (void *)__get_free_page(GFP_KERNEL),
+		.dirent_count = 0
+	};
+	int err;
+
+	if (!r_data.dirent)
+		return false;
+
+	err = cifsd_vfs_kern_path(fp->filename, LOOKUP_FOLLOW | LOOKUP_DIRECTORY,
+			&dir_path, 0);
+	if (err < 0)
+		return false;
+
+	filp = dentry_open(&dir_path, O_RDONLY | O_LARGEFILE, current_cred());
+	if (IS_ERR(filp)) {
+		err = PTR_ERR(filp);
+		fput(filp);
+		cifsd_err("dentry open failed, err %d\n", err);
+		return false;
+	}
+
+	r_data.used = 0;
+	r_data.full = 0;
+
+	err = cifsd_vfs_readdir(filp, smb_filldir, &r_data);
+	if (r_data.dirent_count > 2) {
+		fput(filp);
+		path_put(&dir_path);
+		free_page((unsigned long)(r_data.dirent));
+		return false;
+	}
+
+	free_page((unsigned long)(r_data.dirent));
+	fput(filp);
+	path_put(&dir_path);
+	return true;
+}
+
+
+/**
+ * cifsd_vfs_kern_path() - lookup a file and get path info
+ * @name:	name of file for lookup
+ * @flags:	lookup flags
+ * @path:	if lookup succeed, return path info
+ * @caseless:	caseless filename lookup
+ *
+ * Return:	0 on success, otherwise error
+ */
+int cifsd_vfs_kern_path(char *name, unsigned int flags, struct path *path,
+		bool caseless)
+{
+	int err;
+
+	err = kern_path(name, flags, path);
+	if (err && caseless) {
+		char *filename = strrchr((const char *)name, '/');
+		if (filename == NULL)
+			return err;
+		*(filename++) = '\0';
+		if (strlen(name) == 0) {
+			/* root reached */
+			filename--;
+			*filename = '/';
+			return err;
+		}
+		err = cifsd_vfs_lookup_in_dir(name, filename);
+		if (err)
+			return err;
+		err = kern_path(name, flags, path);
+		return err;
+	} else
+		return err;
+}
+
+/**
+ * cifsd_vfs_lookup_in_dir() - lookup a file in a directory
+ * @dirname:	directory name
+ * @filename:	filename to lookup
+ *
+ * Return:	0 on success, otherwise error
+ */
+int cifsd_vfs_lookup_in_dir(char *dirname, char *filename)
+{
+	struct path dir_path;
+	int ret;
+	struct file *dfilp;
+	int flags = O_RDONLY|O_LARGEFILE;
+	int used_count, reclen;
+	int iter;
+	struct smb_dirent *buf_p;
+	int namelen = strlen(filename);
+	int dirnamelen = strlen(dirname);
+	bool match_found = false;
+	struct smb_readdir_data readdir_data = {
+		.ctx.actor = smb_filldir,
+		.dirent = (void *)__get_free_page(GFP_KERNEL)
+	};
+
+	if (!readdir_data.dirent) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	ret = cifsd_vfs_kern_path(dirname, 0, &dir_path, true);
+	if (ret)
+		goto out;
+
+	dfilp = dentry_open(&dir_path, flags, current_cred());
+	if (IS_ERR(dfilp)) {
+		cifsd_err("cannot open directory %s\n", dirname);
+		ret = -EINVAL;
+		goto out2;
+	}
+
+	while (!ret && !match_found) {
+		readdir_data.used = 0;
+		readdir_data.full = 0;
+		ret = cifsd_vfs_readdir(dfilp, smb_filldir, &readdir_data);
+		used_count = readdir_data.used;
+		if (ret || !used_count)
+			break;
+
+		buf_p = (struct smb_dirent *)readdir_data.dirent;
+		for (iter = 0; iter < used_count; iter += reclen,
+		     buf_p = (struct smb_dirent *)((char *)buf_p + reclen)) {
+			int length;
+
+			reclen = ALIGN(sizeof(struct smb_dirent) +
+				       buf_p->namelen, sizeof(__le64));
+			length = buf_p->namelen;
+			if (length != namelen ||
+				strncasecmp(filename, buf_p->name, namelen))
+				continue;
+			/* got match, make absolute name */
+			memcpy(dirname + dirnamelen + 1, buf_p->name, namelen);
+			match_found = true;
+			break;
+		}
+	}
+
+	free_page((unsigned long)(readdir_data.dirent));
+	fput(dfilp);
+out2:
+	path_put(&dir_path);
+out:
+	dirname[dirnamelen] = '/';
+	return ret;
 }

--- a/vfs.c
+++ b/vfs.c
@@ -1472,7 +1472,7 @@ int cifsd_vfs_lookup_in_dir(char *dirname, char *filename)
 	int flags = O_RDONLY|O_LARGEFILE;
 	int used_count, reclen;
 	int iter;
-	struct smb_dirent *buf_p;
+	struct cifsd_dirent *buf_p;
 	int namelen = strlen(filename);
 	int dirnamelen = strlen(dirname);
 	bool match_found = false;
@@ -1505,12 +1505,12 @@ int cifsd_vfs_lookup_in_dir(char *dirname, char *filename)
 		if (ret || !used_count)
 			break;
 
-		buf_p = (struct smb_dirent *)readdir_data.dirent;
+		buf_p = (struct cifsd_dirent *)readdir_data.dirent;
 		for (iter = 0; iter < used_count; iter += reclen,
-		     buf_p = (struct smb_dirent *)((char *)buf_p + reclen)) {
+		     buf_p = (struct cifsd_dirent *)((char *)buf_p + reclen)) {
 			int length;
 
-			reclen = ALIGN(sizeof(struct smb_dirent) +
+			reclen = ALIGN(sizeof(struct cifsd_dirent) +
 				       buf_p->namelen, sizeof(__le64));
 			length = buf_p->namelen;
 			if (length != namelen ||
@@ -1644,7 +1644,7 @@ static void fill_file_attributes(struct cifsd_work *work,
  */
 char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 			     struct smb_kstat *smb_kstat,
-			     struct smb_dirent *de,
+			     struct cifsd_dirent *de,
 			     char *dirpath)
 {
 	struct path path;

--- a/vfs.h
+++ b/vfs.h
@@ -1,0 +1,95 @@
+#ifndef __CIFSD_VFS_H__
+#define __CIFSD_VFS_H__
+
+#include <linux/file.h>
+#include <linux/fs.h>
+
+struct cifsd_sess;
+struct cifsd_work;
+struct cifsd_file;
+struct cifsd_tcp_conn;
+
+struct cifsd_readdir_data {
+	struct dir_context ctx;
+	char           *dirent;
+	unsigned int   used;
+	unsigned int   full;
+	unsigned int   dirent_count;
+	unsigned int   file_attr;
+};
+
+struct cifsd_dirent {
+	__le64         ino;
+	__le64          offset;
+	__le32         namelen;
+	__le32         d_type;
+	char            name[];
+};
+
+/* cifsd kstat wrapper to get valid create time when reading dir entry */
+struct cifsd_kstat {
+	struct kstat *kstat;
+	__u64 create_time;
+	__le32 file_attributes;
+};
+
+struct smb2_fs_sector_size {
+	unsigned short logical_sector_size;
+	unsigned int physical_sector_size;
+	unsigned int optimal_io_size;
+};
+
+int cifsd_vfs_create(const char *name, umode_t mode);
+int cifsd_vfs_mkdir(const char *name, umode_t mode);
+int cifsd_vfs_read(struct cifsd_work *work, struct cifsd_file *fp,
+		 size_t count, loff_t *pos);
+int cifsd_vfs_write(struct cifsd_sess *sess, struct cifsd_file *fp,
+	char *buf, size_t count, loff_t *pos, bool fsync, ssize_t *written);
+int cifsd_vfs_getattr(struct cifsd_sess *sess, uint64_t fid,
+		struct kstat *stat);
+int cifsd_vfs_setattr(struct cifsd_sess *sess, const char *name,
+		uint64_t fid, struct iattr *attrs);
+int cifsd_vfs_fsync(struct cifsd_sess *sess, uint64_t fid, uint64_t p_id);
+struct cifsd_file *smb_dentry_open(struct cifsd_work *work,
+	const struct path *path, int flags, int option, int fexist);
+int cifsd_vfs_remove_file(char *name);
+int cifsd_vfs_link(const char *oldname, const char *newname);
+int cifsd_vfs_symlink(const char *name, const char *symname);
+int cifsd_vfs_readlink(struct path *path, char *buf, int len);
+int cifsd_vfs_rename(char *abs_oldname, char *abs_newname, struct cifsd_file *fp);
+int cifsd_vfs_truncate(struct cifsd_sess *sess, const char *name,
+	struct cifsd_file *fp, loff_t size);
+ssize_t cifsd_vfs_listxattr(struct dentry *dentry, char **list, int size);
+ssize_t cifsd_vfs_getxattr(struct dentry *dentry, char *xattr_name,
+		char **xattr_buf, int flags);
+struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
+	const struct path *path, int flags, int option, int fexist);
+int cifsd_vfs_setxattr(const char *filename, struct path *path, const char *name,
+		const void *value, size_t size, int flags);
+int cifsd_vfs_kern_path(char *name, unsigned int flags, struct path *path,
+		bool caseless);
+int cifsd_vfs_lookup_in_dir(char *dirname, char *filename);
+bool cifsd_vfs_empty_dir(struct cifsd_file *fp);
+void cifsd_vfs_set_fadvise(struct file *filp, int option);
+int cifsd_vfs_lock(struct file *filp, int cmd, struct file_lock *flock);
+int check_lock_range(struct file *filp, loff_t start,
+		loff_t end, unsigned char type);
+int cifsd_vfs_readdir(struct file *file, filldir_t filler,
+			struct cifsd_readdir_data *buf);
+int cifsd_vfs_alloc_size(struct cifsd_tcp_conn *conn, struct cifsd_file *fp,
+	loff_t len);
+int cifsd_vfs_truncate_xattr(struct dentry *dentry);
+int cifsd_vfs_truncate_stream_xattr(struct dentry *dentry);
+int cifsd_vfs_remove_xattr(struct path *path, char *field_name);
+int cifsd_vfs_unlink(struct dentry *dir, struct dentry *dentry);
+unsigned short cifsd_vfs_logical_sector_size(struct inode *inode);
+void cifsd_vfs_smb2_sector_size(struct inode *inode,
+	struct smb2_fs_sector_size *fs_ss);
+bool cifsd_vfs_empty_dir(struct cifsd_file *fp);
+char *cifsd_vfs_readdir_name(struct cifsd_work *work,
+			     struct cifsd_kstat *cifsd_kstat,
+			     struct cifsd_dirent *de,
+			     char *dirpath);
+void *cifsd_vfs_init_kstat(char **p, struct cifsd_kstat *cifsd_kstat);
+
+#endif /* __CIFSD_VFS_H__ */


### PR DESCRIPTION
        Out VFS wrapper functions have misleading name smb_vfs (which
suggests that those are SMB1 specific) and are scattered across several
files. This is the first patch set that attempts to bring them all
together. The work is incomplete.
