### PR TITLE
XATTR API cleanup

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -530,7 +530,8 @@ static int close_fp(struct cifsd_file *fp)
 
 	if (fp->is_stream && (ci->m_flags & S_DEL_ON_CLS_STREAM)) {
 		ci->m_flags &= ~S_DEL_ON_CLS_STREAM;
-		err = cifsd_vfs_remove_xattr(&(filp->f_path), fp->stream.name);
+		err = cifsd_vfs_remove_xattr(filp->f_path.dentry,
+					     fp->stream.name);
 		if (err)
 			cifsd_err("remove xattr failed : %s\n",
 				fp->stream.name);

--- a/glob.h
+++ b/glob.h
@@ -494,10 +494,6 @@ extern void dump_smb_msg(void *buf, int smb_buf_length);
 extern int switch_rsp_buf(struct cifsd_work *work);
 extern void ntstatus_to_dos(__u32 ntstatus, __u8 *eclass, __u16 *ecode);
 extern struct cifsd_sess *validate_sess_handle(struct cifsd_sess *session);
-extern int smb_store_cont_xattr(struct path *path, char *prefix, void *value,
-	ssize_t v_len);
-extern ssize_t smb_find_cont_xattr(struct path *path, char *prefix, int p_len,
-	char **value, int flags);
 extern int get_pos_strnstr(const char *s1, const char *s2, size_t len);
 extern int smb_check_delete_pending(struct file *filp,
 	struct cifsd_file *curr_fp);

--- a/misc.c
+++ b/misc.c
@@ -423,51 +423,6 @@ int is_smb2_rsp(struct cifsd_work *work)
 };
 #endif
 
-int smb_store_cont_xattr(struct path *path, char *prefix, void *value,
-	ssize_t v_len)
-{
-	int err;
-
-	err = cifsd_vfs_setxattr(NULL, path, prefix, value, v_len, 0);
-	if (err)
-		cifsd_debug("setxattr failed, err %d\n", err);
-
-	return err;
-}
-
-ssize_t smb_find_cont_xattr(struct path *path, char *prefix, int p_len,
-	char **value, int flags)
-{
-	char *name, *xattr_list = NULL;
-	ssize_t value_len = -ENOENT, xattr_list_len;
-
-	xattr_list_len = cifsd_vfs_listxattr(path->dentry, &xattr_list,
-		XATTR_LIST_MAX);
-	if (xattr_list_len < 0) {
-		goto out;
-	} else if (!xattr_list_len) {
-		cifsd_debug("empty xattr in the file\n");
-		goto out;
-	}
-
-	for (name = xattr_list; name - xattr_list < xattr_list_len;
-			name += strlen(name) + 1) {
-		cifsd_debug("%s, len %zd\n", name, strlen(name));
-		if (strncasecmp(prefix, name, p_len))
-			continue;
-
-		value_len = cifsd_vfs_getxattr(path->dentry, name, value, flags);
-		if (value_len < 0)
-			cifsd_err("failed to get xattr in file\n");
-		break;
-	}
-
-out:
-	if (xattr_list)
-		vfree(xattr_list);
-	return value_len;
-}
-
 int get_pos_strnstr(const char *s1, const char *s2, size_t len)
 {
 	size_t l2;

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2790,7 +2790,7 @@ int smb_nt_create_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = cifsd_vfs_getcasexattr(&path,
+			err = cifsd_vfs_getcasexattr(path.dentry,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 			if (err > 0)
@@ -4346,7 +4346,7 @@ static int query_path_info(struct cifsd_work *work)
 	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 		char *ctime = NULL;
 
-		rc = cifsd_vfs_getcasexattr(&path,
+		rc = cifsd_vfs_getcasexattr(path.dentry,
 			XATTR_NAME_CREATION_TIME,
 			XATTR_NAME_CREATION_TIME_LEN, &ctime, 1);
 		if (rc > 0)
@@ -8404,7 +8404,7 @@ int smb_open_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = cifsd_vfs_getcasexattr(&path,
+			err = cifsd_vfs_getcasexattr(path.dentry,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 			if (err > 0)

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2790,7 +2790,7 @@ int smb_nt_create_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = cifsd_vfs_find_cont_xattr(&path,
+			err = cifsd_vfs_getcasexattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 			if (err > 0)
@@ -4346,7 +4346,7 @@ static int query_path_info(struct cifsd_work *work)
 	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 		char *ctime = NULL;
 
-		rc = cifsd_vfs_find_cont_xattr(&path,
+		rc = cifsd_vfs_getcasexattr(&path,
 			XATTR_NAME_CREATION_TIME,
 			XATTR_NAME_CREATION_TIME_LEN, &ctime, 1);
 		if (rc > 0)
@@ -8404,7 +8404,7 @@ int smb_open_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = cifsd_vfs_find_cont_xattr(&path,
+			err = cifsd_vfs_getcasexattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 			if (err > 0)

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2790,9 +2790,8 @@ int smb_nt_create_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = cifsd_vfs_getcasexattr(path.dentry,
+			err = cifsd_vfs_getxattr(path.dentry,
 						XATTR_NAME_CREATION_TIME,
-						XATTR_NAME_CREATION_TIME_LEN,
 						&create_time);
 			if (err > 0)
 				fp->create_time = *((__u64 *)create_time);
@@ -4349,10 +4348,9 @@ static int query_path_info(struct cifsd_work *work)
 	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 		char *ctime = NULL;
 
-		rc = cifsd_vfs_getcasexattr(path.dentry,
-					    XATTR_NAME_CREATION_TIME,
-					    XATTR_NAME_CREATION_TIME_LEN,
-					    &ctime);
+		rc = cifsd_vfs_getxattr(path.dentry,
+					XATTR_NAME_CREATION_TIME,
+					&ctime);
 		if (rc > 0)
 			create_time = *((__u64 *)ctime);
 		cifsd_free(ctime);
@@ -8408,10 +8406,9 @@ int smb_open_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = cifsd_vfs_getcasexattr(path.dentry,
-						XATTR_NAME_CREATION_TIME,
-						XATTR_NAME_CREATION_TIME_LEN,
-						&create_time);
+			err = cifsd_vfs_getxattr(path.dentry,
+						 XATTR_NAME_CREATION_TIME,
+						 &create_time);
 			if (err > 0)
 				fp->create_time = *((__u64 *)create_time);
 			cifsd_free(create_time);

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2801,9 +2801,11 @@ int smb_nt_create_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			err = cifsd_vfs_setxattr(NULL, &path,
-				XATTR_NAME_CREATION_TIME,
-				(void *)&fp->create_time, CREATIOM_TIME_LEN, 0);
+			err = cifsd_vfs_setxattr(&path,
+						 XATTR_NAME_CREATION_TIME,
+						 (void *)&fp->create_time,
+						 CREATIOM_TIME_LEN,
+						 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;
@@ -4048,11 +4050,13 @@ static int smb_set_acl(struct cifsd_work *work)
 
 	value_len = rc;
 	if (acl_type == ACL_TYPE_ACCESS) {
-		rc = cifsd_vfs_setxattr(fname, NULL, XATTR_NAME_POSIX_ACL_ACCESS,
-				buf, value_len, 0);
+		rc = cifsd_vfs_fsetxattr(fname,
+					 XATTR_NAME_POSIX_ACL_ACCESS,
+					 buf, value_len, 0);
 	} else if (acl_type == ACL_TYPE_DEFAULT) {
-		rc = cifsd_vfs_setxattr(fname, NULL, XATTR_NAME_POSIX_ACL_DEFAULT,
-				buf, value_len, 0);
+		rc = cifsd_vfs_fsetxattr(fname,
+					 XATTR_NAME_POSIX_ACL_DEFAULT,
+					 buf, value_len, 0);
 	}
 
 	if (rc < 0) {
@@ -5563,8 +5567,9 @@ static int smb_set_ea(struct cifsd_work *work)
 		cifsd_debug("name: <%s>, name_len %u, value_len %u\n",
 			ea->name, ea->name_len, le16_to_cpu(ea->value_len));
 
-		rc = cifsd_vfs_setxattr(fname, NULL, attr_name, value,
-				le16_to_cpu(ea->value_len), 0);
+		rc = cifsd_vfs_fsetxattr(fname, attr_name, value,
+					le16_to_cpu(ea->value_len),
+					0);
 		if (rc < 0) {
 			kfree(attr_name);
 			rsp->hdr.Status.CifsError =
@@ -7504,9 +7509,11 @@ static int create_dir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = cifsd_vfs_setxattr(NULL, &path,
-				XATTR_NAME_CREATION_TIME,
-				(void *)&create_time, CREATIOM_TIME_LEN, 0);
+			err = cifsd_vfs_setxattr(&path,
+						 XATTR_NAME_CREATION_TIME,
+						 (void *)&create_time,
+						 CREATIOM_TIME_LEN,
+						 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;
@@ -7778,9 +7785,11 @@ int smb_mkdir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = cifsd_vfs_setxattr(NULL, &path,
-				XATTR_NAME_CREATION_TIME,
-				(void *)&create_time, CREATIOM_TIME_LEN, 0);
+			err = cifsd_vfs_setxattr(&path,
+						 XATTR_NAME_CREATION_TIME,
+						 (void *)&create_time,
+						 CREATIOM_TIME_LEN,
+						 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;
@@ -8406,9 +8415,11 @@ int smb_open_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
-			err = cifsd_vfs_setxattr(NULL, &path,
-				XATTR_NAME_CREATION_TIME,
-				(void *)&fp->create_time, CREATIOM_TIME_LEN, 0);
+			err = cifsd_vfs_setxattr(&path,
+						 XATTR_NAME_CREATION_TIME,
+						 (void *)&fp->create_time,
+						 CREATIOM_TIME_LEN,
+						 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2791,8 +2791,9 @@ int smb_nt_create_andx(struct cifsd_work *work)
 			char *create_time = NULL;
 
 			err = cifsd_vfs_getcasexattr(path.dentry,
-				XATTR_NAME_CREATION_TIME,
-				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
+						XATTR_NAME_CREATION_TIME,
+						XATTR_NAME_CREATION_TIME_LEN,
+						&create_time);
 			if (err > 0)
 				fp->create_time = *((__u64 *)create_time);
 			cifsd_free(create_time);
@@ -3956,8 +3957,9 @@ static int smb_get_acl(struct cifsd_work *work, struct path *path)
 	aclbuf->access_entry_count = 0;
 
 	/* check if POSIX_ACL_XATTR_ACCESS exists */
-	value_len = cifsd_vfs_getxattr(path->dentry, XATTR_NAME_POSIX_ACL_ACCESS,
-			&buf, 1);
+	value_len = cifsd_vfs_getxattr(path->dentry,
+				       XATTR_NAME_POSIX_ACL_ACCESS,
+				       &buf);
 	if (value_len > 0) {
 		rsp_data_cnt += ACL_to_cifs_posix((char *)aclbuf, buf,
 				value_len, ACL_TYPE_ACCESS);
@@ -3965,8 +3967,9 @@ static int smb_get_acl(struct cifsd_work *work, struct path *path)
 	}
 
 	/* check if POSIX_ACL_XATTR_DEFAULT exists */
-	value_len = cifsd_vfs_getxattr(path->dentry, XATTR_NAME_POSIX_ACL_DEFAULT,
-			&buf, 1);
+	value_len = cifsd_vfs_getxattr(path->dentry,
+				       XATTR_NAME_POSIX_ACL_DEFAULT,
+				       &buf);
 	if (value_len > 0) {
 		rsp_data_cnt += ACL_to_cifs_posix((char *)aclbuf, buf,
 				value_len, ACL_TYPE_DEFAULT);
@@ -4231,7 +4234,7 @@ static int smb_get_ea(struct cifsd_work *work, struct path *path)
 		ptr = (char *)(&temp_fea->name + name_len + 1);
 		buf_free_len -= (offsetof(struct fea, name) + name_len + 1);
 
-		value_len = cifsd_vfs_getxattr(path->dentry, name, &buf, 1);
+		value_len = cifsd_vfs_getxattr(path->dentry, name, &buf);
 		if (value_len <= 0) {
 			rc = -ENOENT;
 			rsp->hdr.Status.CifsError = NT_STATUS_INVALID_HANDLE;
@@ -4347,8 +4350,9 @@ static int query_path_info(struct cifsd_work *work)
 		char *ctime = NULL;
 
 		rc = cifsd_vfs_getcasexattr(path.dentry,
-			XATTR_NAME_CREATION_TIME,
-			XATTR_NAME_CREATION_TIME_LEN, &ctime, 1);
+					    XATTR_NAME_CREATION_TIME,
+					    XATTR_NAME_CREATION_TIME_LEN,
+					    &ctime);
 		if (rc > 0)
 			create_time = *((__u64 *)ctime);
 		cifsd_free(ctime);
@@ -8405,8 +8409,9 @@ int smb_open_andx(struct cifsd_work *work)
 			char *create_time = NULL;
 
 			err = cifsd_vfs_getcasexattr(path.dentry,
-				XATTR_NAME_CREATION_TIME,
-				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
+						XATTR_NAME_CREATION_TIME,
+						XATTR_NAME_CREATION_TIME_LEN,
+						&create_time);
 			if (err > 0)
 				fp->create_time = *((__u64 *)create_time);
 			cifsd_free(create_time);

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2801,9 +2801,9 @@ int smb_nt_create_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			err = cifsd_vfs_store_cont_xattr(&path,
+			err = cifsd_vfs_setxattr(NULL, &path,
 				XATTR_NAME_CREATION_TIME,
-				(void *)&fp->create_time, CREATIOM_TIME_LEN);
+				(void *)&fp->create_time, CREATIOM_TIME_LEN, 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;
@@ -7504,9 +7504,9 @@ static int create_dir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = cifsd_vfs_store_cont_xattr(&path,
+			err = cifsd_vfs_setxattr(NULL, &path,
 				XATTR_NAME_CREATION_TIME,
-				(void *)&create_time, CREATIOM_TIME_LEN);
+				(void *)&create_time, CREATIOM_TIME_LEN, 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;
@@ -7778,9 +7778,9 @@ int smb_mkdir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = cifsd_vfs_store_cont_xattr(&path,
+			err = cifsd_vfs_setxattr(NULL, &path,
 				XATTR_NAME_CREATION_TIME,
-				(void *)&create_time, CREATIOM_TIME_LEN);
+				(void *)&create_time, CREATIOM_TIME_LEN, 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;
@@ -8406,9 +8406,9 @@ int smb_open_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
-			err = cifsd_vfs_store_cont_xattr(&path,
+			err = cifsd_vfs_setxattr(NULL, &path,
 				XATTR_NAME_CREATION_TIME,
-				(void *)&fp->create_time, CREATIOM_TIME_LEN);
+				(void *)&fp->create_time, CREATIOM_TIME_LEN, 0);
 			if (err)
 				cifsd_debug("failed to store creation time in EA\n");
 			err = 0;

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2801,7 +2801,7 @@ int smb_nt_create_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			err = cifsd_vfs_setxattr(&path,
+			err = cifsd_vfs_setxattr(path.dentry,
 						 XATTR_NAME_CREATION_TIME,
 						 (void *)&fp->create_time,
 						 CREATIOM_TIME_LEN,
@@ -7509,7 +7509,7 @@ static int create_dir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = cifsd_vfs_setxattr(&path,
+			err = cifsd_vfs_setxattr(path.dentry,
 						 XATTR_NAME_CREATION_TIME,
 						 (void *)&create_time,
 						 CREATIOM_TIME_LEN,
@@ -7785,7 +7785,7 @@ int smb_mkdir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = cifsd_vfs_setxattr(&path,
+			err = cifsd_vfs_setxattr(path.dentry,
 						 XATTR_NAME_CREATION_TIME,
 						 (void *)&create_time,
 						 CREATIOM_TIME_LEN,
@@ -8415,7 +8415,7 @@ int smb_open_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
-			err = cifsd_vfs_setxattr(&path,
+			err = cifsd_vfs_setxattr(path.dentry,
 						 XATTR_NAME_CREATION_TIME,
 						 (void *)&fp->create_time,
 						 CREATIOM_TIME_LEN,

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2790,7 +2790,7 @@ int smb_nt_create_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = smb_find_cont_xattr(&path,
+			err = cifsd_vfs_find_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 			if (err > 0)
@@ -2801,7 +2801,7 @@ int smb_nt_create_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			err = smb_store_cont_xattr(&path,
+			err = cifsd_vfs_store_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				(void *)&fp->create_time, CREATIOM_TIME_LEN);
 			if (err)
@@ -4342,7 +4342,7 @@ static int query_path_info(struct cifsd_work *work)
 	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 		char *ctime = NULL;
 
-		rc = smb_find_cont_xattr(&path,
+		rc = cifsd_vfs_find_cont_xattr(&path,
 			XATTR_NAME_CREATION_TIME,
 			XATTR_NAME_CREATION_TIME_LEN, &ctime, 1);
 		if (rc > 0)
@@ -7504,7 +7504,7 @@ static int create_dir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = smb_store_cont_xattr(&path,
+			err = cifsd_vfs_store_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				(void *)&create_time, CREATIOM_TIME_LEN);
 			if (err)
@@ -7778,7 +7778,7 @@ int smb_mkdir(struct cifsd_work *work)
 			generic_fillattr(path.dentry->d_inode, &stat);
 			create_time = cifs_UnixTimeToNT(stat.ctime);
 
-			err = smb_store_cont_xattr(&path,
+			err = cifsd_vfs_store_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				(void *)&create_time, CREATIOM_TIME_LEN);
 			if (err)
@@ -8395,7 +8395,7 @@ int smb_open_andx(struct cifsd_work *work)
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			err = smb_find_cont_xattr(&path,
+			err = cifsd_vfs_find_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 			if (err > 0)
@@ -8406,7 +8406,7 @@ int smb_open_andx(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&work->tcon->share->config.attr)) {
-			err = smb_store_cont_xattr(&path,
+			err = cifsd_vfs_store_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				(void *)&fp->create_time, CREATIOM_TIME_LEN);
 			if (err)

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2075,7 +2075,7 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 		value = (char *)&eabuf->name + eabuf->EaNameLength + 1;
 
 		if (!eabuf->EaValueLength) {
-			rc = smb_find_cont_xattr(path, attr_name,
+			rc = cifsd_vfs_find_cont_xattr(path, attr_name,
 				XATTR_USER_PREFIX_LEN + eabuf->EaNameLength,
 				NULL, 0);
 
@@ -2628,7 +2628,7 @@ int smb2_open(struct cifsd_work *work)
 		fp->stream.size = xattr_stream_size;
 
 		/* Check if there is stream prefix in xattr space */
-		rc = smb_find_cont_xattr(&path, xattr_stream_name,
+		rc = cifsd_vfs_find_cont_xattr(&path, xattr_stream_name,
 				xattr_stream_size, NULL, 0);
 		if (rc < 0) {
 			if (fp->cdoption == FILE_OPEN_LE) {
@@ -2800,11 +2800,11 @@ int smb2_open(struct cifsd_work *work)
 
 	if ((file_info != FILE_OPENED) && !S_ISDIR(file_inode(filp)->i_mode)) {
 		/* Create default data stream in xattr */
-		smb_store_cont_xattr(&path, XATTR_NAME_STREAM, NULL, 0);
+		cifsd_vfs_store_cont_xattr(&path, XATTR_NAME_STREAM, NULL, 0);
 	}
 
 	if (store_stream) {
-		rc = smb_store_cont_xattr(&path, xattr_stream_name, NULL, 0);
+		rc = cifsd_vfs_store_cont_xattr(&path, xattr_stream_name, NULL, 0);
 		if (rc < 0) {
 			cifsd_err("failed to store stream name in xattr, rc :%d\n",
 					rc);
@@ -2823,7 +2823,7 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			rc = smb_find_cont_xattr(&path,
+			rc = cifsd_vfs_find_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 
@@ -2836,7 +2836,7 @@ int smb2_open(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			rc = smb_store_cont_xattr(&path,
+			rc = cifsd_vfs_store_cont_xattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				(void *)&fp->create_time, CREATIOM_TIME_LEN);
 			if (rc)
@@ -2853,7 +2853,7 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *file_attribute = NULL;
 
-			rc = smb_find_cont_xattr(&path,
+			rc = cifsd_vfs_find_cont_xattr(&path,
 				 XATTR_NAME_FILE_ATTRIBUTE,
 				 XATTR_NAME_FILE_ATTRIBUTE_LEN,
 				 &file_attribute, 1);
@@ -2867,7 +2867,7 @@ int smb2_open(struct cifsd_work *work)
 	} else {
 		/* set XATTR_NAME_FILE_ATTRIBUTE with req->FileAttributes */
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			rc = smb_store_cont_xattr(&path,
+			rc = cifsd_vfs_store_cont_xattr(&path,
 				XATTR_NAME_FILE_ATTRIBUTE,
 				(void *)&fp->fattr, FILE_ATTRIBUTE_LEN);
 
@@ -4848,7 +4848,7 @@ static int smb2_rename(struct cifsd_file *fp,
 		xattr_stream_size = construct_xattr_stream_name(stream_name,
 			&xattr_stream_name);
 
-		rc = smb_store_cont_xattr(&fp->filp->f_path, xattr_stream_name,
+		rc = cifsd_vfs_store_cont_xattr(&fp->filp->f_path, xattr_stream_name,
 				NULL, 0);
 		if (rc < 0) {
 			cifsd_err("failed to store stream name in xattr, rc :%d\n",
@@ -5023,7 +5023,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 		if (le64_to_cpu(file_info->CreationTime)) {
 			fp->create_time = le64_to_cpu(file_info->CreationTime);
 			if (get_attr_store_dos(&share->config.attr)) {
-				rc = smb_store_cont_xattr(&filp->f_path,
+				rc = cifsd_vfs_store_cont_xattr(&filp->f_path,
 					XATTR_NAME_CREATION_TIME,
 					(void *)&fp->create_time,
 					CREATIOM_TIME_LEN);
@@ -5070,7 +5070,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 			fp->fattr = cpu_to_le32(smb2_get_dos_mode(&stat,
 					le32_to_cpu(file_info->Attributes)));
 			if (get_attr_store_dos(config_attr)) {
-				rc = smb_store_cont_xattr(&filp->f_path,
+				rc = cifsd_vfs_store_cont_xattr(&filp->f_path,
 						XATTR_NAME_FILE_ATTRIBUTE,
 						(void *)&fp->fattr,
 						FILE_ATTRIBUTE_LEN);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2075,7 +2075,7 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 		value = (char *)&eabuf->name + eabuf->EaNameLength + 1;
 
 		if (!eabuf->EaValueLength) {
-			rc = cifsd_vfs_find_cont_xattr(path, attr_name,
+			rc = cifsd_vfs_getcasexattr(path, attr_name,
 				XATTR_USER_PREFIX_LEN + eabuf->EaNameLength,
 				NULL, 0);
 
@@ -2627,7 +2627,7 @@ int smb2_open(struct cifsd_work *work)
 		fp->stream.size = xattr_stream_size;
 
 		/* Check if there is stream prefix in xattr space */
-		rc = cifsd_vfs_find_cont_xattr(&path, xattr_stream_name,
+		rc = cifsd_vfs_getcasexattr(&path, xattr_stream_name,
 				xattr_stream_size, NULL, 0);
 		if (rc < 0) {
 			if (fp->cdoption == FILE_OPEN_LE) {
@@ -2824,7 +2824,7 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			rc = cifsd_vfs_find_cont_xattr(&path,
+			rc = cifsd_vfs_getcasexattr(&path,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 
@@ -2856,7 +2856,7 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *file_attribute = NULL;
 
-			rc = cifsd_vfs_find_cont_xattr(&path,
+			rc = cifsd_vfs_getcasexattr(&path,
 				 XATTR_NAME_FILE_ATTRIBUTE,
 				 XATTR_NAME_FILE_ATTRIBUTE_LEN,
 				 &file_attribute, 1);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2075,7 +2075,7 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 		value = (char *)&eabuf->name + eabuf->EaNameLength + 1;
 
 		if (!eabuf->EaValueLength) {
-			rc = cifsd_vfs_getcasexattr(path, attr_name,
+			rc = cifsd_vfs_getcasexattr(path->dentry, attr_name,
 				XATTR_USER_PREFIX_LEN + eabuf->EaNameLength,
 				NULL, 0);
 
@@ -2627,7 +2627,7 @@ int smb2_open(struct cifsd_work *work)
 		fp->stream.size = xattr_stream_size;
 
 		/* Check if there is stream prefix in xattr space */
-		rc = cifsd_vfs_getcasexattr(&path, xattr_stream_name,
+		rc = cifsd_vfs_getcasexattr(path.dentry, xattr_stream_name,
 				xattr_stream_size, NULL, 0);
 		if (rc < 0) {
 			if (fp->cdoption == FILE_OPEN_LE) {
@@ -2824,7 +2824,7 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			rc = cifsd_vfs_getcasexattr(&path,
+			rc = cifsd_vfs_getcasexattr(path.dentry,
 				XATTR_NAME_CREATION_TIME,
 				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 
@@ -2856,7 +2856,7 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *file_attribute = NULL;
 
-			rc = cifsd_vfs_getcasexattr(&path,
+			rc = cifsd_vfs_getcasexattr(path.dentry,
 				 XATTR_NAME_FILE_ATTRIBUTE,
 				 XATTR_NAME_FILE_ATTRIBUTE_LEN,
 				 &file_attribute, 1);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2075,9 +2075,10 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 		value = (char *)&eabuf->name + eabuf->EaNameLength + 1;
 
 		if (!eabuf->EaValueLength) {
-			rc = cifsd_vfs_getcasexattr(path->dentry, attr_name,
-				XATTR_USER_PREFIX_LEN + eabuf->EaNameLength,
-				NULL, 0);
+			rc = cifsd_vfs_casexattr_len(path->dentry,
+						     attr_name,
+						     XATTR_USER_PREFIX_LEN +
+						     eabuf->EaNameLength);
 
 			/* delete the EA only when it exits */
 			if (rc > 0) {
@@ -2628,8 +2629,9 @@ int smb2_open(struct cifsd_work *work)
 		fp->stream.size = xattr_stream_size;
 
 		/* Check if there is stream prefix in xattr space */
-		rc = cifsd_vfs_getcasexattr(path.dentry, xattr_stream_name,
-				xattr_stream_size, NULL, 0);
+		rc = cifsd_vfs_casexattr_len(path.dentry,
+					     xattr_stream_name,
+					     xattr_stream_size);
 		if (rc < 0) {
 			if (fp->cdoption == FILE_OPEN_LE) {
 				cifsd_err("failed to find stream name in xattr, rc : %d\n",
@@ -2826,8 +2828,9 @@ int smb2_open(struct cifsd_work *work)
 			char *create_time = NULL;
 
 			rc = cifsd_vfs_getcasexattr(path.dentry,
-				XATTR_NAME_CREATION_TIME,
-				XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
+						XATTR_NAME_CREATION_TIME,
+						XATTR_NAME_CREATION_TIME_LEN,
+						&create_time);
 
 			if (rc > 0)
 				fp->create_time = *((__u64 *)create_time);
@@ -2858,10 +2861,9 @@ int smb2_open(struct cifsd_work *work)
 			char *file_attribute = NULL;
 
 			rc = cifsd_vfs_getcasexattr(path.dentry,
-				 XATTR_NAME_FILE_ATTRIBUTE,
-				 XATTR_NAME_FILE_ATTRIBUTE_LEN,
-				 &file_attribute, 1);
-
+						 XATTR_NAME_FILE_ATTRIBUTE,
+						 XATTR_NAME_FILE_ATTRIBUTE_LEN,
+						 &file_attribute);
 			if (rc > 0)
 				fp->fattr = *((__le32 *)file_attribute);
 
@@ -3666,7 +3668,7 @@ static int smb2_get_ea(struct cifsd_tcp_conn *conn, struct path *path,
 		buf_free_len -= (offsetof(struct smb2_ea_info, name) +
 				name_len + 1);
 		/* bailout if xattr can't fit in buf_free_len */
-		value_len = cifsd_vfs_getxattr(path->dentry, name, &buf, 1);
+		value_len = cifsd_vfs_getxattr(path->dentry, name, &buf);
 		if (value_len <= 0) {
 			rc = -ENOENT;
 			rsp->hdr.Status = NT_STATUS_INVALID_HANDLE;

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2827,9 +2827,8 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *create_time = NULL;
 
-			rc = cifsd_vfs_getcasexattr(path.dentry,
+			rc = cifsd_vfs_getxattr(path.dentry,
 						XATTR_NAME_CREATION_TIME,
-						XATTR_NAME_CREATION_TIME_LEN,
 						&create_time);
 
 			if (rc > 0)
@@ -2860,10 +2859,9 @@ int smb2_open(struct cifsd_work *work)
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
 			char *file_attribute = NULL;
 
-			rc = cifsd_vfs_getcasexattr(path.dentry,
-						 XATTR_NAME_FILE_ATTRIBUTE,
-						 XATTR_NAME_FILE_ATTRIBUTE_LEN,
-						 &file_attribute);
+			rc = cifsd_vfs_getxattr(path.dentry,
+						XATTR_NAME_FILE_ATTRIBUTE,
+						&file_attribute);
 			if (rc > 0)
 				fp->fattr = *((__le32 *)file_attribute);
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2094,7 +2094,7 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 			/* if the EA doesn't exist, just do nothing. */
 			rc = 0;
 		} else {
-			rc = cifsd_vfs_setxattr(path, attr_name, value,
+			rc = cifsd_vfs_setxattr(path->dentry, attr_name, value,
 					le16_to_cpu(eabuf->EaValueLength), 0);
 			if (rc < 0) {
 				cifsd_err("cifsd_vfs_setxattr is failed(%d)\n",
@@ -2800,12 +2800,12 @@ int smb2_open(struct cifsd_work *work)
 
 	if ((file_info != FILE_OPENED) && !S_ISDIR(file_inode(filp)->i_mode)) {
 		/* Create default data stream in xattr */
-		cifsd_vfs_setxattr(&path, XATTR_NAME_STREAM,
+		cifsd_vfs_setxattr(path.dentry, XATTR_NAME_STREAM,
 				   NULL, 0, 0);
 	}
 
 	if (store_stream) {
-		rc = cifsd_vfs_setxattr(&path, xattr_stream_name,
+		rc = cifsd_vfs_setxattr(path.dentry, xattr_stream_name,
 					NULL, 0, 0);
 		if (rc < 0) {
 			cifsd_err("failed to store stream name in xattr, rc :%d\n",
@@ -2838,7 +2838,7 @@ int smb2_open(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			rc = cifsd_vfs_setxattr(&path,
+			rc = cifsd_vfs_setxattr(path.dentry,
 						XATTR_NAME_CREATION_TIME,
 						(void *)&fp->create_time,
 						CREATIOM_TIME_LEN,
@@ -2871,7 +2871,7 @@ int smb2_open(struct cifsd_work *work)
 	} else {
 		/* set XATTR_NAME_FILE_ATTRIBUTE with req->FileAttributes */
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			rc = cifsd_vfs_setxattr(&path,
+			rc = cifsd_vfs_setxattr(path.dentry,
 						XATTR_NAME_FILE_ATTRIBUTE,
 						(void *)&fp->fattr,
 						FILE_ATTRIBUTE_LEN,
@@ -4852,7 +4852,7 @@ static int smb2_rename(struct cifsd_file *fp,
 		xattr_stream_size = construct_xattr_stream_name(stream_name,
 			&xattr_stream_name);
 
-		rc = cifsd_vfs_setxattr(&fp->filp->f_path,
+		rc = cifsd_vfs_setxattr(fp->filp->f_path.dentry,
 					xattr_stream_name,
 					NULL, 0, 0);
 		if (rc < 0) {
@@ -5028,7 +5028,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 		if (le64_to_cpu(file_info->CreationTime)) {
 			fp->create_time = le64_to_cpu(file_info->CreationTime);
 			if (get_attr_store_dos(&share->config.attr)) {
-				rc = cifsd_vfs_setxattr(&filp->f_path,
+				rc = cifsd_vfs_setxattr(filp->f_path.dentry,
 						XATTR_NAME_CREATION_TIME,
 						(void *)&fp->create_time,
 						CREATIOM_TIME_LEN, 0);
@@ -5075,7 +5075,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 			fp->fattr = cpu_to_le32(smb2_get_dos_mode(&stat,
 					le32_to_cpu(file_info->Attributes)));
 			if (get_attr_store_dos(config_attr)) {
-				rc = cifsd_vfs_setxattr(&filp->f_path,
+				rc = cifsd_vfs_setxattr(filp->f_path.dentry,
 						XATTR_NAME_FILE_ATTRIBUTE,
 						(void *)&fp->fattr,
 						FILE_ATTRIBUTE_LEN, 0);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2800,11 +2800,13 @@ int smb2_open(struct cifsd_work *work)
 
 	if ((file_info != FILE_OPENED) && !S_ISDIR(file_inode(filp)->i_mode)) {
 		/* Create default data stream in xattr */
-		cifsd_vfs_store_cont_xattr(&path, XATTR_NAME_STREAM, NULL, 0);
+		cifsd_vfs_setxattr(NULL, &path, XATTR_NAME_STREAM,
+				   NULL, 0, 0);
 	}
 
 	if (store_stream) {
-		rc = cifsd_vfs_store_cont_xattr(&path, xattr_stream_name, NULL, 0);
+		rc = cifsd_vfs_setxattr(NULL, &path, xattr_stream_name,
+					NULL, 0, 0);
 		if (rc < 0) {
 			cifsd_err("failed to store stream name in xattr, rc :%d\n",
 					rc);
@@ -2836,9 +2838,9 @@ int smb2_open(struct cifsd_work *work)
 	} else {
 		fp->create_time = cifs_UnixTimeToNT(stat.ctime);
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			rc = cifsd_vfs_store_cont_xattr(&path,
+			rc = cifsd_vfs_setxattr(NULL, &path,
 				XATTR_NAME_CREATION_TIME,
-				(void *)&fp->create_time, CREATIOM_TIME_LEN);
+				(void *)&fp->create_time, CREATIOM_TIME_LEN, 0);
 			if (rc)
 				cifsd_debug("failed to store creation time in EA\n");
 			rc = 0;
@@ -2867,9 +2869,9 @@ int smb2_open(struct cifsd_work *work)
 	} else {
 		/* set XATTR_NAME_FILE_ATTRIBUTE with req->FileAttributes */
 		if (get_attr_store_dos(&tcon->share->config.attr)) {
-			rc = cifsd_vfs_store_cont_xattr(&path,
+			rc = cifsd_vfs_setxattr(NULL, &path,
 				XATTR_NAME_FILE_ATTRIBUTE,
-				(void *)&fp->fattr, FILE_ATTRIBUTE_LEN);
+				(void *)&fp->fattr, FILE_ATTRIBUTE_LEN, 0);
 
 			if (rc)
 				cifsd_debug("failed to store file attribute in EA\n");
@@ -4848,8 +4850,9 @@ static int smb2_rename(struct cifsd_file *fp,
 		xattr_stream_size = construct_xattr_stream_name(stream_name,
 			&xattr_stream_name);
 
-		rc = cifsd_vfs_store_cont_xattr(&fp->filp->f_path, xattr_stream_name,
-				NULL, 0);
+		rc = cifsd_vfs_setxattr(NULL, &fp->filp->f_path,
+				xattr_stream_name,
+				NULL, 0, 0);
 		if (rc < 0) {
 			cifsd_err("failed to store stream name in xattr, rc :%d\n",
 					rc);
@@ -5023,10 +5026,10 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 		if (le64_to_cpu(file_info->CreationTime)) {
 			fp->create_time = le64_to_cpu(file_info->CreationTime);
 			if (get_attr_store_dos(&share->config.attr)) {
-				rc = cifsd_vfs_store_cont_xattr(&filp->f_path,
+				rc = cifsd_vfs_setxattr(NULL, &filp->f_path,
 					XATTR_NAME_CREATION_TIME,
 					(void *)&fp->create_time,
-					CREATIOM_TIME_LEN);
+					CREATIOM_TIME_LEN, 0);
 				if (rc) {
 					cifsd_debug("failed to set creation time\n");
 					rc = -EINVAL;
@@ -5070,10 +5073,10 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 			fp->fattr = cpu_to_le32(smb2_get_dos_mode(&stat,
 					le32_to_cpu(file_info->Attributes)));
 			if (get_attr_store_dos(config_attr)) {
-				rc = cifsd_vfs_store_cont_xattr(&filp->f_path,
+				rc = cifsd_vfs_setxattr(NULL, &filp->f_path,
 						XATTR_NAME_FILE_ATTRIBUTE,
 						(void *)&fp->fattr,
-						FILE_ATTRIBUTE_LEN);
+						FILE_ATTRIBUTE_LEN, 0);
 
 				if (rc)
 					cifsd_debug("failed to store file attribute in EA\n");

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2081,7 +2081,8 @@ static int smb2_set_ea(struct smb2_ea_info *eabuf, struct path *path)
 
 			/* delete the EA only when it exits */
 			if (rc > 0) {
-				rc = cifsd_vfs_remove_xattr(path, attr_name);
+				rc = cifsd_vfs_remove_xattr(path->dentry,
+							    attr_name);
 
 				if (rc < 0) {
 					cifsd_err("remove xattr failed(%d)\n",

--- a/vfs.c
+++ b/vfs.c
@@ -236,8 +236,8 @@ static int cifsd_vfs_stream_write(struct cifsd_file *fp, char *buf, loff_t *pos,
 
 	memcpy(&stream_buf[*pos], buf, count);
 
-	err = cifsd_vfs_store_cont_xattr(&fp->filp->f_path, fp->stream.name,
-			(void *)stream_buf, size);
+	err = cifsd_vfs_setxattr(NULL, &fp->filp->f_path, fp->stream.name,
+			(void *)stream_buf, size, 0);
 	if (err < 0)
 		goto out;
 
@@ -1688,20 +1688,6 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 	name[de->namelen] = '\0';
 	path_put(&path);
 	return name;
-}
-
-int cifsd_vfs_store_cont_xattr(struct path *path,
-			       char *prefix,
-			       void *value,
-			       ssize_t v_len)
-{
-	int err;
-
-	err = cifsd_vfs_setxattr(NULL, path, prefix, value, v_len, 0);
-	if (err)
-		cifsd_debug("setxattr failed, err %d\n", err);
-
-	return err;
 }
 
 ssize_t cifsd_vfs_find_cont_xattr(struct path *path,

--- a/vfs.c
+++ b/vfs.c
@@ -109,7 +109,7 @@ static int cifsd_vfs_stream_read(struct cifsd_file *fp, char *buf, loff_t *pos,
 	cifsd_debug("read stream data pos : %llu, count : %zd\n",
 			*pos, count);
 
-	v_len = cifsd_vfs_find_cont_xattr(&fp->filp->f_path, fp->stream.name,
+	v_len = cifsd_vfs_getcasexattr(&fp->filp->f_path, fp->stream.name,
 			fp->stream.size, &stream_buf, 1);
 	if (v_len == -ENOENT) {
 		cifsd_err("not found stream in xattr : %zd\n", v_len);
@@ -214,7 +214,7 @@ static int cifsd_vfs_stream_write(struct cifsd_file *fp, char *buf, loff_t *pos,
 		count = (*pos + count) - XATTR_SIZE_MAX;
 	}
 
-	v_len = cifsd_vfs_find_cont_xattr(&fp->filp->f_path, fp->stream.name,
+	v_len = cifsd_vfs_getcasexattr(&fp->filp->f_path, fp->stream.name,
 			fp->stream.size, &stream_buf, 1);
 	if (v_len == -ENOENT) {
 		cifsd_err("not found stream in xattr : %zd\n", v_len);
@@ -1581,7 +1581,7 @@ static void fill_create_time(struct cifsd_work *work,
 	cifsd_kstat->create_time = cifs_UnixTimeToNT(cifsd_kstat->kstat->ctime);
 
 	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
-		xattr_len = cifsd_vfs_find_cont_xattr(path,
+		xattr_len = cifsd_vfs_getcasexattr(path,
 			XATTR_NAME_CREATION_TIME,
 			XATTR_NAME_CREATION_TIME_LEN, &create_time, 1);
 
@@ -1646,7 +1646,7 @@ static void fill_file_attributes(struct cifsd_work *work,
 		char *file_attribute = NULL;
 		int rc;
 
-		rc = cifsd_vfs_find_cont_xattr(path,
+		rc = cifsd_vfs_getcasexattr(path,
 			XATTR_NAME_FILE_ATTRIBUTE,
 			XATTR_NAME_FILE_ATTRIBUTE_LEN, &file_attribute, 1);
 
@@ -1710,31 +1710,31 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 	return name;
 }
 
-ssize_t cifsd_vfs_find_cont_xattr(struct path *path,
-				  char *prefix,
-				  int p_len,
-				  char **value,
-				  int flags)
+ssize_t cifsd_vfs_getcasexattr(struct path *path,
+				char *attr_name,
+				int attr_name_len,
+				char **attr_value,
+				int flags)
 {
 	char *name, *xattr_list = NULL;
 	ssize_t value_len = -ENOENT, xattr_list_len;
 
-	xattr_list_len = cifsd_vfs_listxattr(path->dentry, &xattr_list,
-		XATTR_LIST_MAX);
-	if (xattr_list_len < 0) {
+	xattr_list_len = cifsd_vfs_listxattr(path->dentry,
+					     &xattr_list,
+					     XATTR_LIST_MAX);
+	if (xattr_list_len <= 0)
 		goto out;
-	} else if (!xattr_list_len) {
-		cifsd_debug("empty xattr in the file\n");
-		goto out;
-	}
 
 	for (name = xattr_list; name - xattr_list < xattr_list_len;
 			name += strlen(name) + 1) {
 		cifsd_debug("%s, len %zd\n", name, strlen(name));
-		if (strncasecmp(prefix, name, p_len))
+		if (strncasecmp(attr_name, name, attr_name_len))
 			continue;
 
-		value_len = cifsd_vfs_getxattr(path->dentry, name, value, flags);
+		value_len = cifsd_vfs_getxattr(path->dentry,
+					       name,
+					       attr_value,
+					       flags);
 		if (value_len < 0)
 			cifsd_err("failed to get xattr in file\n");
 		break;

--- a/vfs.c
+++ b/vfs.c
@@ -1584,10 +1584,9 @@ static void fill_create_time(struct cifsd_work *work,
 	cifsd_kstat->create_time = cifs_UnixTimeToNT(cifsd_kstat->kstat->ctime);
 
 	if (get_attr_store_dos(&work->tcon->share->config.attr)) {
-		xattr_len = cifsd_vfs_getcasexattr(path->dentry,
-					XATTR_NAME_CREATION_TIME,
-					XATTR_NAME_CREATION_TIME_LEN,
-					&create_time);
+		xattr_len = cifsd_vfs_getxattr(path->dentry,
+					       XATTR_NAME_CREATION_TIME,
+					       &create_time);
 		if (xattr_len > 0)
 			cifsd_kstat->create_time = *((u64 *)create_time);
 
@@ -1649,9 +1648,8 @@ static void fill_file_attributes(struct cifsd_work *work,
 		char *file_attribute = NULL;
 		int rc;
 
-		rc = cifsd_vfs_getcasexattr(path->dentry,
+		rc = cifsd_vfs_getxattr(path->dentry,
 					XATTR_NAME_FILE_ATTRIBUTE,
-					XATTR_NAME_FILE_ATTRIBUTE_LEN,
 					&file_attribute);
 		if (rc > 0)
 			cifsd_kstat->file_attributes =

--- a/vfs.c
+++ b/vfs.c
@@ -242,7 +242,7 @@ static int cifsd_vfs_stream_write(struct cifsd_file *fp, char *buf, loff_t *pos,
 
 	memcpy(&stream_buf[*pos], buf, count);
 
-	err = cifsd_vfs_setxattr(&fp->filp->f_path,
+	err = cifsd_vfs_setxattr(fp->filp->f_path.dentry,
 				 fp->stream.name,
 				 (void *)stream_buf,
 				 size,
@@ -995,7 +995,7 @@ ssize_t cifsd_vfs_getxattr(struct dentry *dentry, char *xattr_name,
 
 /**
  * cifsd_vfs_setxattr() - vfs helper for smb set extended attributes value
- * @fpath:	path of file for setxattr
+ * @dentry:	dentry to set XATTR at
  * @name:	xattr name for setxattr
  * @value:	xattr value to set
  * @size:	size of xattr value
@@ -1003,7 +1003,7 @@ ssize_t cifsd_vfs_getxattr(struct dentry *dentry, char *xattr_name,
  *
  * Return:	0 on success, otherwise error
  */
-int cifsd_vfs_setxattr(struct path *fpath,
+int cifsd_vfs_setxattr(struct dentry *dentry,
 		       const char *attr_name,
 		       const void *attr_value,
 		       size_t attr_size,
@@ -1011,7 +1011,7 @@ int cifsd_vfs_setxattr(struct path *fpath,
 {
 	int err;
 
-	err = vfs_setxattr(fpath->dentry,
+	err = vfs_setxattr(dentry,
 			   attr_name,
 			   attr_value,
 			   attr_size,

--- a/vfs.c
+++ b/vfs.c
@@ -1234,9 +1234,9 @@ int cifsd_vfs_alloc_size(struct cifsd_work *work,
 	return vfs_fallocate(fp->filp, FALLOC_FL_KEEP_SIZE, 0, len);
 }
 
-int cifsd_vfs_remove_xattr(struct path *path, char *field_name)
+int cifsd_vfs_remove_xattr(struct dentry *dentry, char *attr_name)
 {
-	return vfs_removexattr(path->dentry, field_name);
+	return vfs_removexattr(dentry, attr_name);
 }
 
 int cifsd_vfs_unlink(struct dentry *dir, struct dentry *dentry)

--- a/vfs.h
+++ b/vfs.h
@@ -113,11 +113,6 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 			     char *dirpath);
 void *cifsd_vfs_init_kstat(char **p, struct cifsd_kstat *cifsd_kstat);
 
-int cifsd_vfs_store_cont_xattr(struct path *path,
-			       char *prefix,
-			       void *value,
-			       ssize_t v_len);
-
 ssize_t cifsd_vfs_find_cont_xattr(struct path *path,
 				  char *prefix,
 				  int p_len,

--- a/vfs.h
+++ b/vfs.h
@@ -83,9 +83,19 @@ ssize_t cifsd_vfs_getxattr(struct dentry *dentry, char *xattr_name,
 		char **xattr_buf, int flags);
 struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
 	const struct path *path, int flags, int option, int fexist);
-int cifsd_vfs_setxattr(const char *filename, struct path *path,
-		       const char *name,
-		       const void *value, size_t size, int flags);
+
+int cifsd_vfs_setxattr(struct path *path,
+		       const char *attr_name,
+		       const void *attr_value,
+		       size_t attr_size,
+		       int flags);
+
+int cifsd_vfs_fsetxattr(const char *filename,
+			const char *attr_name,
+			const void *attr_value,
+			size_t attr_size,
+			int flags);
+
 int cifsd_vfs_kern_path(char *name, unsigned int flags, struct path *path,
 		bool caseless);
 int cifsd_vfs_lookup_in_dir(char *dirname, char *filename);

--- a/vfs.h
+++ b/vfs.h
@@ -86,7 +86,7 @@ ssize_t cifsd_vfs_getxattr(struct dentry *dentry,
 			   char **xattr_buf,
 			   int flags);
 
-int cifsd_vfs_setxattr(struct path *path,
+int cifsd_vfs_setxattr(struct dentry *dentry,
 		       const char *attr_name,
 		       const void *attr_value,
 		       size_t attr_size,

--- a/vfs.h
+++ b/vfs.h
@@ -123,7 +123,7 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 			     char *dirpath);
 void *cifsd_vfs_init_kstat(char **p, struct cifsd_kstat *cifsd_kstat);
 
-ssize_t cifsd_vfs_getcasexattr(struct path *path,
+ssize_t cifsd_vfs_getcasexattr(struct dentry *dentry,
 			       char *attr_name,
 			       int attr_name_len,
 			       char **attr_value,

--- a/vfs.h
+++ b/vfs.h
@@ -66,10 +66,6 @@ int cifsd_vfs_getattr(struct cifsd_work *work, uint64_t fid,
 int cifsd_vfs_setattr(struct cifsd_work *work, const char *name,
 		uint64_t fid, struct iattr *attrs);
 int cifsd_vfs_fsync(struct cifsd_work *work, uint64_t fid, uint64_t p_id);
-struct cifsd_file *smb_dentry_open(struct cifsd_work *work,
-				   const struct path *path,
-				   int flags, int option,
-				   int fexist);
 int cifsd_vfs_remove_file(char *name);
 int cifsd_vfs_link(const char *oldname, const char *newname);
 int cifsd_vfs_symlink(const char *name, const char *symname);
@@ -78,11 +74,17 @@ int cifsd_vfs_rename(char *abs_oldname, char *abs_newname,
 		     struct cifsd_file *fp);
 int cifsd_vfs_truncate(struct cifsd_work *work, const char *name,
 	struct cifsd_file *fp, loff_t size);
-ssize_t cifsd_vfs_listxattr(struct dentry *dentry, char **list, int size);
-ssize_t cifsd_vfs_getxattr(struct dentry *dentry, char *xattr_name,
-		char **xattr_buf, int flags);
 struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
-	const struct path *path, int flags, int option, int fexist);
+					 const struct path *path,
+					 int flags,
+					 int option,
+					 int fexist);
+
+ssize_t cifsd_vfs_listxattr(struct dentry *dentry, char **list, int size);
+ssize_t cifsd_vfs_getxattr(struct dentry *dentry,
+			   char *xattr_name,
+			   char **xattr_buf,
+			   int flags);
 
 int cifsd_vfs_setxattr(struct path *path,
 		       const char *attr_name,

--- a/vfs.h
+++ b/vfs.h
@@ -113,4 +113,15 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 			     char *dirpath);
 void *cifsd_vfs_init_kstat(char **p, struct cifsd_kstat *cifsd_kstat);
 
+int cifsd_vfs_store_cont_xattr(struct path *path,
+			       char *prefix,
+			       void *value,
+			       ssize_t v_len);
+
+ssize_t cifsd_vfs_find_cont_xattr(struct path *path,
+				  char *prefix,
+				  int p_len,
+				  char **value,
+				  int flags);
+
 #endif /* __CIFSD_VFS_H__ */

--- a/vfs.h
+++ b/vfs.h
@@ -123,10 +123,10 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 			     char *dirpath);
 void *cifsd_vfs_init_kstat(char **p, struct cifsd_kstat *cifsd_kstat);
 
-ssize_t cifsd_vfs_find_cont_xattr(struct path *path,
-				  char *prefix,
-				  int p_len,
-				  char **value,
-				  int flags);
+ssize_t cifsd_vfs_getcasexattr(struct path *path,
+			       char *attr_name,
+			       int attr_name_len,
+			       char **attr_value,
+			       int flags);
 
 #endif /* __CIFSD_VFS_H__ */

--- a/vfs.h
+++ b/vfs.h
@@ -83,8 +83,14 @@ struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
 ssize_t cifsd_vfs_listxattr(struct dentry *dentry, char **list, int size);
 ssize_t cifsd_vfs_getxattr(struct dentry *dentry,
 			   char *xattr_name,
-			   char **xattr_buf,
-			   int flags);
+			   char **xattr_buf);
+
+ssize_t cifsd_vfs_xattr_len(struct dentry *dentry,
+			    char *xattr_name);
+
+ssize_t cifsd_vfs_casexattr_len(struct dentry *dentry,
+				char *attr_name,
+				int attr_name_len);
 
 int cifsd_vfs_setxattr(struct dentry *dentry,
 		       const char *attr_name,
@@ -105,8 +111,7 @@ int cifsd_vfs_remove_xattr(struct dentry *dentry, char *attr_name);
 ssize_t cifsd_vfs_getcasexattr(struct dentry *dentry,
 			       char *attr_name,
 			       int attr_name_len,
-			       char **attr_value,
-			       int flags);
+			       char **attr_value);
 
 int cifsd_vfs_kern_path(char *name, unsigned int flags, struct path *path,
 		bool caseless);

--- a/vfs.h
+++ b/vfs.h
@@ -113,7 +113,7 @@ int cifsd_vfs_alloc_size(struct cifsd_work *work,
 			 loff_t len);
 int cifsd_vfs_truncate_xattr(struct dentry *dentry);
 int cifsd_vfs_truncate_stream_xattr(struct dentry *dentry);
-int cifsd_vfs_remove_xattr(struct path *path, char *field_name);
+int cifsd_vfs_remove_xattr(struct dentry *dentry, char *attr_name);
 int cifsd_vfs_unlink(struct dentry *dir, struct dentry *dentry);
 unsigned short cifsd_vfs_logical_sector_size(struct inode *inode);
 void cifsd_vfs_smb2_sector_size(struct inode *inode,

--- a/vfs.h
+++ b/vfs.h
@@ -98,6 +98,16 @@ int cifsd_vfs_fsetxattr(const char *filename,
 			size_t attr_size,
 			int flags);
 
+int cifsd_vfs_truncate_xattr(struct dentry *dentry);
+int cifsd_vfs_truncate_stream_xattr(struct dentry *dentry);
+int cifsd_vfs_remove_xattr(struct dentry *dentry, char *attr_name);
+
+ssize_t cifsd_vfs_getcasexattr(struct dentry *dentry,
+			       char *attr_name,
+			       int attr_name_len,
+			       char **attr_value,
+			       int flags);
+
 int cifsd_vfs_kern_path(char *name, unsigned int flags, struct path *path,
 		bool caseless);
 int cifsd_vfs_lookup_in_dir(char *dirname, char *filename);
@@ -111,9 +121,6 @@ int cifsd_vfs_readdir(struct file *file, filldir_t filler,
 int cifsd_vfs_alloc_size(struct cifsd_work *work,
 			 struct cifsd_file *fp,
 			 loff_t len);
-int cifsd_vfs_truncate_xattr(struct dentry *dentry);
-int cifsd_vfs_truncate_stream_xattr(struct dentry *dentry);
-int cifsd_vfs_remove_xattr(struct dentry *dentry, char *attr_name);
 int cifsd_vfs_unlink(struct dentry *dir, struct dentry *dentry);
 unsigned short cifsd_vfs_logical_sector_size(struct inode *inode);
 void cifsd_vfs_smb2_sector_size(struct inode *inode,
@@ -124,11 +131,5 @@ char *cifsd_vfs_readdir_name(struct cifsd_work *work,
 			     struct cifsd_dirent *de,
 			     char *dirpath);
 void *cifsd_vfs_init_kstat(char **p, struct cifsd_kstat *cifsd_kstat);
-
-ssize_t cifsd_vfs_getcasexattr(struct dentry *dentry,
-			       char *attr_name,
-			       int attr_name_len,
-			       char **attr_value,
-			       int flags);
 
 #endif /* __CIFSD_VFS_H__ */


### PR DESCRIPTION
        The patch set cleans up XATTR API: unifies APIs, consolidates,
introduces new API and some memory and performance optimizations.