### PR TITLE
cifsd: move find_fp_using_inode()

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -415,6 +415,32 @@ struct cifsd_file *find_fp_using_filename(struct cifsd_sess *sess,
 	return file;
 }
 
+struct cifsd_file *find_fp_using_inode(struct inode *inode)
+{
+	struct cifsd_file *lfp;
+	struct cifsd_inode *ci;
+	struct list_head *cur;
+
+	ci = cifsd_inode_lookup_by_vfsinode(inode);
+	if (!ci)
+		goto out;
+
+	spin_lock(&ci->m_lock);
+	list_for_each(cur, &ci->m_fp_list) {
+		lfp = list_entry(cur, struct cifsd_file, node);
+		if (inode == FP_INODE(lfp)) {
+			atomic_dec(&ci->m_count);
+			spin_unlock(&ci->m_lock);
+			return lfp;
+		}
+	}
+	atomic_dec(&ci->m_count);
+	spin_unlock(&ci->m_lock);
+
+out:
+	return NULL;
+}
+
 /**
  * delete_id_from_fidtable() - delete a fid from fid table
  * @conn:	TCP server instance of connection

--- a/fh.h
+++ b/fh.h
@@ -242,6 +242,7 @@ struct cifsd_file *lookup_fp_clguid(char *createguid);
 struct cifsd_file *lookup_fp_app_id(char *app_id);
 struct cifsd_file *find_fp_using_filename(struct cifsd_sess *sess,
 	char *filename);
+struct cifsd_file *find_fp_using_inode(struct inode *inode);
 int close_disconnected_handle(struct inode *inode);
 #endif
 

--- a/glob.h
+++ b/glob.h
@@ -499,7 +499,6 @@ extern int smb_check_delete_pending(struct file *filp,
 	struct cifsd_file *curr_fp);
 extern int smb_check_shared_mode(struct file *filp,
 	struct cifsd_file *curr_fp);
-extern struct cifsd_file *find_fp_using_inode(struct inode *inode);
 extern void remove_async_id(__u64 async_id);
 extern int pattern_cmp(const char *string, const char *pattern);
 extern bool is_matched(const char *fname, const char *exp);

--- a/misc.c
+++ b/misc.c
@@ -565,32 +565,6 @@ int smb_check_shared_mode(struct file *filp, struct cifsd_file *curr_fp)
 	return rc;
 }
 
-struct cifsd_file *find_fp_using_inode(struct inode *inode)
-{
-	struct cifsd_file *lfp;
-	struct cifsd_inode *ci;
-	struct list_head *cur;
-
-	ci = cifsd_inode_lookup_by_vfsinode(inode);
-	if (!ci)
-		goto out;
-
-	spin_lock(&ci->m_lock);
-	list_for_each(cur, &ci->m_fp_list) {
-		lfp = list_entry(cur, struct cifsd_file, node);
-		if (inode == FP_INODE(lfp)) {
-			atomic_dec(&ci->m_count);
-			spin_unlock(&ci->m_lock);
-			return lfp;
-		}
-	}
-	atomic_dec(&ci->m_count);
-	spin_unlock(&ci->m_lock);
-
-out:
-	return NULL;
-}
-
 /**
  * pattern_cmp() - compare a string with a pattern which might include
  * wildcard '*' and '?'

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -33,6 +33,7 @@
 #include "buffer_pool.h"
 #include "transport_tcp.h"
 #include "vfs.h"
+#include "fh.h"
 
 bool multi_channel_enable;
 

--- a/vfs.c
+++ b/vfs.c
@@ -36,6 +36,7 @@
 #include "transport_tcp.h"
 #include "buffer_pool.h"
 #include "vfs.h"
+#include "fh.h"
 
 /**
  * cifsd_vfs_create() - vfs helper for smb create file


### PR DESCRIPTION
find_fp_using_inode() belongs to fh.c and fh.h. Move it out
of misc.c and glob.h (which must die).

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>