### PR TITLE
cifsd: do not access TCP conn internals from server, use a new API to…

### DIFF
--- a/mgmt/user_session.c
+++ b/mgmt/user_session.c
@@ -202,6 +202,20 @@ void cifsd_session_register(struct cifsd_tcp_conn *conn,
 	list_add(&sess->sessions_entry, &conn->sessions);
 }
 
+void cifsd_sessions_deregister(struct cifsd_tcp_conn *conn)
+{
+	struct cifsd_session *sess;
+
+	while (!list_empty(&conn->sessions)) {
+		sess = list_entry(conn->sessions.next,
+				  struct cifsd_session,
+				  sessions_entry);
+
+		list_del(&sess->sessions_entry);
+		cifsd_session_destroy(sess);
+	}
+}
+
 bool cifsd_session_id_match(struct cifsd_session *sess, unsigned long long id)
 {
 	return sess->id == id;

--- a/mgmt/user_session.h
+++ b/mgmt/user_session.h
@@ -103,6 +103,7 @@ struct cifsd_session *cifsd_session_lookup(struct cifsd_tcp_conn *conn,
 					   unsigned long long id);
 void cifsd_session_register(struct cifsd_tcp_conn *conn,
 			    struct cifsd_session *sess);
+void cifsd_sessions_deregister(struct cifsd_tcp_conn *conn);
 
 int cifsd_acquire_tree_conn_id(struct cifsd_session *sess);
 void cifsd_release_tree_conn_id(struct cifsd_session *sess, int id);

--- a/server.c
+++ b/server.c
@@ -378,17 +378,7 @@ static int cifsd_server_process_request(struct cifsd_tcp_conn *conn)
 
 static int cifsd_server_terminate_conn(struct cifsd_tcp_conn *conn)
 {
-	if (!list_empty(&conn->sessions)) {
-		struct cifsd_session *sess;
-		struct list_head *tmp, *t;
-		list_for_each_safe(tmp, t, &conn->sessions) {
-			sess = list_entry(tmp,
-					  struct cifsd_session,
-					  sessions_entry);
-			cifsd_session_destroy(sess);
-		}
-	}
-
+	cifsd_sessions_deregister(conn);
 	destroy_lease_table(conn);
 	return 0;
 }


### PR DESCRIPTION
… destroy all TCP conn sessions

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>