### PR TITLE
cifsd: downgrade "cant open dir" to a debug message

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2408,7 +2408,7 @@ int smb2_open(struct cifsd_work *work)
 	if (file_present && req->CreateOptions & FILE_NON_DIRECTORY_FILE_LE
 		&& S_ISDIR(stat.mode) &&
 		!(req->CreateOptions & FILE_DELETE_ON_CLOSE_LE)) {
-		cifsd_err("Can't open dir %s, request is to open file : %x\n",
+		cifsd_debug("open() argument is a directory: %s, %x\n",
 			      name, req->CreateOptions);
 		rsp->hdr.Status = NT_STATUS_FILE_IS_A_DIRECTORY;
 		rc = -EIO;


### PR DESCRIPTION
This appears to be a "normal" windows behaviour

[ 4151.582446] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60
[ 4151.583742] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60
[ 4151.597687] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 68
[ 4152.194573] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60
[ 4152.195409] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60
[ 4152.207293] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 68
[ 4153.196053] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60
[ 4153.197290] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60
[ 4153.211300] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 68
[ 4154.195061] kcifsd: smb2_open:2411: Can't open dir /media/edev/share1, request is to open file : 60

so change error print out to a debug print out.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>