### PR TITLE
cifsd: convert all net share name to lowercase

### DIFF
--- a/mgmt/share_config.c
+++ b/mgmt/share_config.c
@@ -196,9 +196,19 @@ out:
 	return share;
 }
 
+static void strtolower(char *share_name)
+{
+	while (*share_name) {
+		*share_name = tolower(*share_name);
+		share_name++;
+	}
+}
+
 struct cifsd_share_config *cifsd_share_config_get(char *name)
 {
 	struct cifsd_share_config *share;
+
+	strtolower(name);
 
 	down_read(&shares_table_lock);
 	share = __share_lookup(name);


### PR DESCRIPTION
Windows does not tolerate upper/lower-case share names and treats
them equally. So should we. cifsd-tools will convert all share names
to a lower case, but we need to do the same on the kernel side as
well - to make share cache usable.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>
Reported-by: Namjae Jeon <namjae.jeon@protocolfreedom.org>