### PR TITLE
cifsd: drop duplicate config options, and do not leak memory on module exit

### DIFF
--- a/server.c
+++ b/server.c
@@ -387,12 +387,12 @@ static void cifsd_server_tcp_callbacks_init(void)
 
 static void server_conf_free(void)
 {
-	kfree(server_conf.netbios_name);
-	kfree(server_conf.server_string);
-	kfree(server_conf.work_group);
-	server_conf.netbios_name = NULL;
-	server_conf.server_string = NULL;
-	server_conf.work_group = NULL;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(server_conf.conf); i++) {
+		kfree(server_conf.conf[i]);
+		server_conf.conf[i] = NULL;
+	}
 }
 
 static int server_conf_init(void)

--- a/server.h
+++ b/server.h
@@ -30,9 +30,6 @@
 struct cifsd_server_config {
 	int		state;
 	char		*conf[SERVER_CONF_WORK_GROUP + 1];
-	char		*netbios_name;
-	char		*server_string;
-	char		*work_group;
 
 	short		signing;
 	short		enforced_signing;

--- a/server.h
+++ b/server.h
@@ -49,12 +49,12 @@ char *cifsd_work_group(void);
 
 static inline int cifsd_server_running(void)
 {
-	return server_conf.state == SERVER_STATE_STARTING_UP;
+	return server_conf.state == SERVER_STATE_RUNNING;
 }
 
 static inline void cifsd_server_set_running(void)
 {
-	server_conf.state = SERVER_STATE_STARTING_UP;
+	server_conf.state = SERVER_STATE_RUNNING;
 }
 
 int cifsd_server_shutdown(void);


### PR DESCRIPTION

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>