### PR TITLE
cifsd: add cifsd_debugging module param

### DIFF
--- a/export.h
+++ b/export.h
@@ -31,7 +31,7 @@
 #include "smb2pdu.h"
 #endif
 
-extern int cifsd_debug_enable;
+extern int cifsd_debugging;
 
 /* Global defines for server */
 #define SERVER_MAX_MPX_COUNT 10

--- a/glob.h
+++ b/glob.h
@@ -57,7 +57,7 @@
 
 /* @FIXME clean up this code */
 
-extern int cifsd_debug_enable;
+extern int cifsd_debugging;
 extern int cifsd_caseless_search;
 extern bool oplocks_enable;
 extern bool lease_enable;
@@ -435,7 +435,7 @@ struct FileNotifyInformation {
 
 #define cifsd_debug(fmt, ...)					\
 	do {							\
-		if (cifsd_debug_enable)				\
+		if (cifsd_debugging)				\
 			pr_err("kcifsd: %s:%d: " fmt,		\
 			__func__, __LINE__, ##__VA_ARGS__);	\
 	} while (0)

--- a/misc.c
+++ b/misc.c
@@ -159,7 +159,7 @@ void dump_smb_msg(void *buf, int smb_buf_length)
 	char debug_line[33];
 	unsigned char *buffer = buf;
 
-	if (likely(cifsd_debug_enable != 2))
+	if (likely(cifsd_debugging != 2))
 		return;
 
 	for (i = 0, j = 0; i < smb_buf_length; i++, j++) {

--- a/server.c
+++ b/server.c
@@ -35,9 +35,9 @@
 #include "transport_ipc.h"
 #include "mgmt/user_session.h"
 
-/* @FIXME clean up this code */
-int cifsd_debug_enable;
+int cifsd_debugging;
 
+/* @FIXME clean up this code */
 /*
  * keep MaxBufSize Default: 65536
  * CIFSMaxBufSize can have it in Range: 8192 to 130048(default 16384)
@@ -138,7 +138,7 @@ static void handle_cifsd_work(struct work_struct *wk)
 
 	cifsd_tcp_conn_lock(conn);
 
-	if (cifsd_debug_enable)
+	if (cifsd_debugging)
 		start_time = jiffies;
 
 	conn->stats.request_served++;
@@ -285,7 +285,7 @@ send:
 	cifsd_tcp_write(work);
 
 nosend:
-	if (cifsd_debug_enable) {
+	if (cifsd_debugging) {
 		end_time = jiffies;
 
 		time_elapsed = end_time - start_time;
@@ -478,6 +478,9 @@ static void __exit cifsd_server_exit(void)
 {
 	cifsd_server_shutdown();
 }
+
+module_param(cifsd_debugging, int, 0644);
+MODULE_PARM_DESC(cifsd_debugging, "Enable/disable CIFSD debugging output");
 
 MODULE_AUTHOR("Namjae Jeon <namjae.jeon@protocolfreedom.org>");
 MODULE_DESCRIPTION("Linux kernel CIFS/SMB SERVER");


### PR DESCRIPTION
Usage example:

modprobe cifsd cifsd_debugging=2

or

echo 2 > /sys/module/cifsd/parameters/cifsd_debugging

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>