### PR TITLE
cifsd: start fileid from 0

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -222,13 +222,13 @@ int cifsd_auth_ntlm(struct cifsd_session *sess, char *pw_buf)
 
 	memset(p21, '\0', 21);
 	memcpy(p21, user_passkey(sess->user), CIFS_NTHASH_SIZE);
-	rc = E_P24(p21, sess->ntlmssp.cryptkey, key);
+	rc = cifsd_enc_p24(p21, sess->ntlmssp.cryptkey, key);
 	if (rc) {
 		cifsd_err("password processing failed\n");
 		return rc;
 	}
 
-	smb_mdfour(sess->sess_key,
+	cifsd_enc_md4(sess->sess_key,
 			user_passkey(sess->user),
 			CIFS_SMB1_SESSKEY_SIZE);
 	memcpy(sess->sess_key + CIFS_SMB1_SESSKEY_SIZE, key,
@@ -346,8 +346,9 @@ static int __cifsd_auth_ntlmv2(struct cifsd_session *sess,
 	unsigned char p21[21];
 	char key[CIFS_AUTH_RESP_SIZE];
 
-	rc = update_sess_key(sess_key, client_nonce,
-		(char *)sess->ntlmssp.cryptkey, 8);
+	rc = cifsd_enc_update_sess_key(sess_key,
+				       client_nonce,
+				       (char *)sess->ntlmssp.cryptkey, 8);
 	if (rc) {
 		cifsd_err("password processing failed\n");
 		goto out;
@@ -355,7 +356,7 @@ static int __cifsd_auth_ntlmv2(struct cifsd_session *sess,
 
 	memset(p21, '\0', 21);
 	memcpy(p21, user_passkey(sess->user), CIFS_NTHASH_SIZE);
-	rc = E_P24(p21, sess_key, key);
+	rc = cifsd_enc_p24(p21, sess_key, key);
 	if (rc) {
 		cifsd_err("password processing failed\n");
 		goto out;

--- a/auth.c
+++ b/auth.c
@@ -15,6 +15,7 @@
 #include "auth.h"
 #include "glob.h"
 
+#include "encrypt.h"
 #include "server.h"
 #include "smb_common.h"
 #include "transport_tcp.h"

--- a/encrypt.c
+++ b/encrypt.c
@@ -23,19 +23,6 @@
 #include "unicode.h"
 #include "encrypt.h"
 
-#ifndef false
-#define false 0
-#endif
-#ifndef true
-#define true 1
-#endif
-
-/* following came from the other byteorder.h to avoid include conflicts */
-#define CVAL(buf, pos) (((unsigned char *)(buf))[(pos)])
-#define SSVALX(buf, pos, val)	\
-	(CVAL((buf), (pos)) = (val) & 0xFF, CVAL((buf), (pos)+1) = (val) >> 8)
-#define SSVAL(buf, pos, val) SSVALX((buf), (pos), ((__u16)(val)))
-
 static void
 str_to_key(unsigned char *str, unsigned char *key)
 {
@@ -210,8 +197,8 @@ err_out:
  * Creates the MD4 Hash of the users password in NT UNICODE.
  */
 int cifsd_enc_md4hash(const unsigned char *passwd,
-		  unsigned char *p16,
-		  const struct nls_table *codepage)
+		      unsigned char *p16,
+		      const struct nls_table *codepage)
 {
 	int rc;
 	int len;

--- a/encrypt.c
+++ b/encrypt.c
@@ -100,7 +100,9 @@ static int E_P16(unsigned char *p14, unsigned char *p16)
 	return rc;
 }
 
-int E_P24(unsigned char *p21, const unsigned char *c8, unsigned char *p24)
+int cifsd_enc_p24(unsigned char *p21,
+		  const unsigned char *c8,
+		  unsigned char *p24)
 {
 	int rc;
 
@@ -115,7 +117,9 @@ int E_P24(unsigned char *p21, const unsigned char *c8, unsigned char *p24)
 }
 
 /* produce a md4 message digest from data of length n bytes */
-int smb_mdfour(unsigned char *md4_hash, unsigned char *link_str, int link_len)
+int cifsd_enc_md4(unsigned char *md4_hash,
+		  unsigned char *link_str,
+		  int link_len)
 {
 	int rc;
 	unsigned int size;
@@ -160,10 +164,10 @@ smb_mdfour_err:
 }
 
 /* produce sess key using md5 with client nonce and server chanllenge */
-int update_sess_key(unsigned char *md5_hash,
-		    char *nonce,
-		    char *server_challenge,
-		    int len)
+int cifsd_enc_update_sess_key(unsigned char *md5_hash,
+			      char *nonce,
+			      char *server_challenge,
+			      int len)
 {
 	int rc;
 	unsigned int size;
@@ -237,16 +241,14 @@ int SMB_encrypt(unsigned char *passwd,
 		return rc;
 
 	memcpy(p21, p16, 16);
-	rc = E_P24(p21, c8, p24);
-
+	rc = cifsd_enc_p24(p21, c8, p24);
 	return rc;
 }
 
 /*
  * Creates the MD4 Hash of the users password in NT UNICODE.
  */
-
-int smb_E_md4hash(const unsigned char *passwd,
+int cifsd_enc_md4hash(const unsigned char *passwd,
 		  unsigned char *p16,
 		  const struct nls_table *codepage)
 {
@@ -262,17 +264,16 @@ int smb_E_md4hash(const unsigned char *passwd,
 		*wpwd = 0; /* Ensure string is null terminated */
 	}
 
-	rc = smb_mdfour(p16, (unsigned char *) wpwd, len * sizeof(__le16));
+	rc = cifsd_enc_md4(p16, (unsigned char *) wpwd, len * sizeof(__le16));
 	memset(wpwd, 0, 129 * sizeof(__le16));
-
 	return rc;
 }
 
 /* Does the NT MD4 hash then des encryption. */
-int SMB_NTencrypt(unsigned char *passwd,
-		  unsigned char *c8,
-		  unsigned char *p24,
-		  const struct nls_table *codepage)
+int cifsd_enc_ntmd4(unsigned char *passwd,
+		    unsigned char *c8,
+		    unsigned char *p24,
+		    const struct nls_table *codepage)
 {
 	int rc;
 	unsigned char p16[16], p21[21];
@@ -280,13 +281,13 @@ int SMB_NTencrypt(unsigned char *passwd,
 	memset(p16, '\0', 16);
 	memset(p21, '\0', 21);
 
-	rc = smb_E_md4hash(passwd, p16, codepage);
+	rc = cifsd_enc_md4hash(passwd, p16, codepage);
 	if (rc) {
 		cifsd_debug("%s Can't generate NT hash, error: %d\n",
 				__func__, rc);
 		return rc;
 	}
 	memcpy(p21, p16, 16);
-	rc = E_P24(p21, c8, p24);
+	rc = cifsd_enc_p24(p21, c8, p24);
 	return rc;
 }

--- a/encrypt.h
+++ b/encrypt.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *  Unix SMB/Netbios implementation.
+ *  Version 1.9.
+ *  SMB parameters and setup
+ *  Copyright (C) Andrew Tridgell 1992-2000
+ *  Copyright (C) Luke Kenneth Casson Leighton 1996-2000
+ *  Modified by Jeremy Allison 1995.
+ *  Copyright (C) Andrew Bartlett <abartlet@samba.org> 2002-2003
+ *  Modified by Steve French (sfrench@us.ibm.com) 2002-2003
+ *
+ *  Copyright (C) 2018 Samsung Electronics Co., Ltd.
+ */
+
+#ifndef __ENCRYPT_H__
+#define __ENCRYPT_H__
+
+struct shash_desc;
+
+/* crypto security descriptor definition */
+struct sdesc {
+	struct shash_desc	shash;
+	char			ctx[];
+};
+
+int SMB_NTencrypt(unsigned char *,
+		  unsigned char *,
+		  unsigned char *,
+		  const struct nls_table *);
+
+int smb_E_md4hash(const unsigned char *passwd,
+		  unsigned char *p16,
+		  const struct nls_table *codepage);
+
+int E_P24(unsigned char *p21,
+	  const unsigned char *c8,
+	  unsigned char *p24);
+
+int smb_mdfour(unsigned char *md4_hash,
+	       unsigned char *link_str,
+	       int link_len);
+
+int update_sess_key(unsigned char *md5_hash,
+		    char *nonce,
+		    char *server_challenge,
+		    int len);
+#endif /* __ENCRYPT_H__ */

--- a/encrypt.h
+++ b/encrypt.h
@@ -23,11 +23,6 @@ struct sdesc {
 	char			ctx[];
 };
 
-int cifsd_enc_ntmd4(unsigned char *,
-		    unsigned char *,
-		    unsigned char *,
-		    const struct nls_table *);
-
 int cifsd_enc_md4hash(const unsigned char *passwd,
 		      unsigned char *p16,
 		      const struct nls_table *codepage);

--- a/encrypt.h
+++ b/encrypt.h
@@ -23,25 +23,25 @@ struct sdesc {
 	char			ctx[];
 };
 
-int SMB_NTencrypt(unsigned char *,
-		  unsigned char *,
-		  unsigned char *,
-		  const struct nls_table *);
+int cifsd_enc_ntmd4(unsigned char *,
+		    unsigned char *,
+		    unsigned char *,
+		    const struct nls_table *);
 
-int smb_E_md4hash(const unsigned char *passwd,
-		  unsigned char *p16,
-		  const struct nls_table *codepage);
+int cifsd_enc_md4hash(const unsigned char *passwd,
+		      unsigned char *p16,
+		      const struct nls_table *codepage);
 
-int E_P24(unsigned char *p21,
-	  const unsigned char *c8,
-	  unsigned char *p24);
+int cifsd_enc_p24(unsigned char *p21,
+		  const unsigned char *c8,
+		  unsigned char *p24);
 
-int smb_mdfour(unsigned char *md4_hash,
-	       unsigned char *link_str,
-	       int link_len);
+int cifsd_enc_md4(unsigned char *md4_hash,
+		  unsigned char *link_str,
+		  int link_len);
 
-int update_sess_key(unsigned char *md5_hash,
-		    char *nonce,
-		    char *server_challenge,
-		    int len);
+int cifsd_enc_update_sess_key(unsigned char *md5_hash,
+			      char *nonce,
+			      char *server_challenge,
+			      int len);
 #endif /* __ENCRYPT_H__ */

--- a/fh.c
+++ b/fh.c
@@ -242,7 +242,7 @@ int init_fidtable(struct fidtable_desc *ftab_desc)
 		return -ENOMEM;
 	}
 	ftab_desc->ftab->max_fids = CIFSD_NR_OPEN_DEFAULT;
-	ftab_desc->ftab->start_pos = 1;
+	ftab_desc->ftab->start_pos = 0;
 	spin_lock_init(&ftab_desc->fidtable_lock);
 	return 0;
 }

--- a/glob.h
+++ b/glob.h
@@ -190,12 +190,6 @@ extern struct list_head global_lock_list;
 #define XATTR_NAME_SD_DACL	(XATTR_USER_PREFIX SD_DACL_PREFIX)
 #define XATTR_NAME_SD_DACL_LEN	(sizeof(XATTR_NAME_SD_DACL) - 1)
 
-/* crypto security descriptor definition */
-struct sdesc {
-	struct shash_desc shash;
-	char ctx[];
-};
-
 struct smb_version_values {
 	char            *version_string;
 	__u16           protocol_id;
@@ -438,16 +432,4 @@ static inline struct timespec from_kern_timespec(struct timespec64 ts)
 extern void ntstatus_to_dos(__u32 ntstatus, __u8 *eclass, __u16 *ecode);
 extern int smb_check_delete_pending(struct file *filp,
 	struct cifsd_file *curr_fp);
-
-/* functions */
-extern int SMB_NTencrypt(unsigned char *, unsigned char *, unsigned char *,
-		const struct nls_table *);
-extern int smb_E_md4hash(const unsigned char *passwd, unsigned char *p16,
-		const struct nls_table *codepage);
-extern int E_P24(unsigned char *p21, const unsigned char *c8,
-		unsigned char *p24);
-extern int smb_mdfour(unsigned char *md4_hash, unsigned char *link_str,
-		int link_len);
-extern int update_sess_key(unsigned char *md5_hash, char *nonce,
-	char *server_challenge, int len);
 #endif /* __CIFSD_GLOB_H */

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4287,8 +4287,9 @@ static int smb2_get_info_filesystem(struct cifsd_session *sess,
 			obj_info = (struct object_id_info *)(rsp->Buffer);
 
 			if (!user_guest(sess->user)) {
-				smb_E_md4hash(user_passkey(sess->user),
-					objid, conn->local_nls);
+				cifsd_enc_md4hash(user_passkey(sess->user),
+						  objid,
+						  conn->local_nls);
 				memcpy(obj_info->objid, objid, 16);
 			} else
 				memset(obj_info->objid, 0, 16);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -17,6 +17,7 @@
 
 #include "auth.h"
 #include "asn1.h"
+#include "encrypt.h"
 #include "buffer_pool.h"
 #include "transport_tcp.h"
 #include "transport_ipc.h"


### PR DESCRIPTION
SMB1 spec says the following:

https://msdn.microsoft.com/en-us/library/ff470197.aspx

- The FID MUST be a 16-bit opaque value.
- The FID MUST be unique within a specified client/server SMB
 connection.
- The FID MUST remain valid for the lifetime of the SMB connection
 on which the open request is performed, or until the client sends
 a request to the server to close the FID.
- Once a FID has been closed, the value can be reused for another
 create or open request.
- The value 0xFFFF MUST NOT be used as a valid FID. All other possible
 values for FID, including zero (0x0000) are valid. The value 0xFFFF
 is used to specify all FIDs or no FID, depending upon the context in
 which it is used.

SMB2 spec does not define any limitations on FID value range:

https://msdn.microsoft.com/en-us/library/cc246513.aspx

The only case is that that value 0xffffffffffffffff is special
in some cases.

So we can use FileId 0.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>