### PR TITLE
cifsd: use CIFSD_START_FID in fh

### DIFF
--- a/fh.c
+++ b/fh.c
@@ -576,7 +576,7 @@ int close_id(struct cifsd_session *sess, uint64_t id, uint64_t p_id)
 {
 	struct cifsd_file *fp;
 
-	if (p_id > 0) {
+	if (p_id != CIFSD_NO_FID) {
 		fp = cifsd_get_global_fp(p_id);
 		if (!fp || fp->sess != sess) {
 			cifsd_err("Invalid id for close: %llu\n", p_id);
@@ -741,7 +741,7 @@ struct cifsd_file *cifsd_get_global_fp(uint64_t pid)
 
 	spin_lock(&global_fidtable.fidtable_lock);
 	ftab = global_fidtable.ftab;
-	if ((pid < CIFSD_START_FID) || (pid > ftab->max_fids - 1)) {
+	if (pid > ftab->max_fids - 1) {
 		cifsd_err("invalid persistentID (%lld)\n", pid);
 		spin_unlock(&global_fidtable.fidtable_lock);
 		return NULL;

--- a/fh.c
+++ b/fh.c
@@ -242,7 +242,7 @@ int init_fidtable(struct fidtable_desc *ftab_desc)
 		return -ENOMEM;
 	}
 	ftab_desc->ftab->max_fids = CIFSD_NR_OPEN_DEFAULT;
-	ftab_desc->ftab->start_pos = 0;
+	ftab_desc->ftab->start_pos = CIFSD_START_FID;
 	spin_lock_init(&ftab_desc->fidtable_lock);
 	return 0;
 }

--- a/fh.c
+++ b/fh.c
@@ -939,14 +939,12 @@ int close_disconnected_handle(struct inode *inode)
 					(S_DEL_ON_CLS | S_DEL_PENDING))
 					unlinked = false;
 				spin_lock(&fp->f_lock);
-				if (fp->f_state == FP_FREEING) {
-					spin_unlock(&fp->f_lock);
-					continue;
+				if (fp->f_state != FP_FREEING) {
+					list_del(&fp->node);
+					list_add(&fp->node, &dispose);
+					fp->f_state = FP_FREEING;
 				}
-				list_del(&fp->node);
-				fp->f_state = FP_FREEING;
 				spin_unlock(&fp->f_lock);
-				list_add(&fp->node, &dispose);
 			}
 		}
 		spin_unlock(&ci->m_lock);

--- a/fh.h
+++ b/fh.h
@@ -22,7 +22,7 @@
 
 /* Max id limit is 0xFFFF, so create bitmap with only this size*/
 #define CIFSD_BITMAP_SIZE        0xFFFF
-#define CIFSD_START_FID		 1
+#define CIFSD_START_FID		 0
 
 #define cifsd_set_bit			__set_bit_le
 #define cifsd_test_and_set_bit	__test_and_set_bit_le

--- a/fh.h
+++ b/fh.h
@@ -21,8 +21,9 @@
 #define	FILE_GENERIC_EXECUTE	0X1200a0
 
 /* Max id limit is 0xFFFF, so create bitmap with only this size*/
-#define CIFSD_BITMAP_SIZE        0xFFFF
-#define CIFSD_START_FID		 0
+#define CIFSD_BITMAP_SIZE	0xFFFF
+#define CIFSD_START_FID		0
+#define CIFSD_NO_FID		(-1ULL)
 
 #define cifsd_set_bit			__set_bit_le
 #define cifsd_test_and_set_bit	__test_and_set_bit_le

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -2653,7 +2653,7 @@ int smb_close(struct cifsd_work *work)
 	if ((req->LastWriteTime > 0) && (req->LastWriteTime < 0xFFFFFFFF))
 		cifsd_info("need to set last modified time before close\n");
 
-	err = close_id(work->sess, req->FileID, 0);
+	err = close_id(work->sess, req->FileID, CIFSD_NO_FID);
 	if (err)
 		goto out;
 
@@ -5942,7 +5942,7 @@ static int find_first(struct cifsd_work *work)
 		cifsd_debug("%s end of search\n", __func__);
 		params->EndofSearch = cpu_to_le16(1);
 		path_put(&(dir_fp->filp->f_path));
-		close_id(sess, dir_fp->volatile_id, 0);
+		close_id(sess, dir_fp->volatile_id, CIFSD_NO_FID);
 	}
 	params->EAErrorOffset = cpu_to_le16(0);
 
@@ -5976,7 +5976,7 @@ err_out:
 			dir_fp->readdir_data.dirent = NULL;
 		}
 		path_put(&(dir_fp->filp->f_path));
-		close_id(sess, dir_fp->volatile_id, 0);
+		close_id(sess, dir_fp->volatile_id, CIFSD_NO_FID);
 	}
 
 	if (rsp->hdr.Status.CifsError == 0)
@@ -6155,7 +6155,7 @@ static int find_next(struct cifsd_work *work)
 		params->EndofSearch = cpu_to_le16(1);
 		params->LastNameOffset = cpu_to_le16(0);
 		path_put(&(dir_fp->filp->f_path));
-		close_id(sess, sid, 0);
+		close_id(sess, sid, CIFSD_NO_FID);
 	}
 	params->EAErrorOffset = cpu_to_le16(0);
 
@@ -6189,7 +6189,7 @@ err_out:
 			dir_fp->readdir_data.dirent = NULL;
 		}
 		path_put(&(dir_fp->filp->f_path));
-		close_id(sess, sid, 0);
+		close_id(sess, sid, CIFSD_NO_FID);
 	}
 
 	if (rsp->hdr.Status.CifsError == 0)
@@ -7636,7 +7636,7 @@ int smb_closedir(struct cifsd_work *work)
 
 	cifsd_debug("SMB_COM_FIND_CLOSE2 called for fid %u\n", req->FileID);
 
-	err = close_id(work->sess, req->FileID, 0);
+	err = close_id(work->sess, req->FileID, CIFSD_NO_FID);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
init_fidtable() uses hard-coded value, while the rest of the
functions use CIFSD_START_FID. Set CIFSD_START_FID to 0 and
use it in init_fidtable().

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>