### PR TITLE
cifsd: rewrite CIFSD_IPC_MSG_PAYLOAD to make static analyzer happy

### DIFF
--- a/transport_ipc.c
+++ b/transport_ipc.c
@@ -58,8 +58,8 @@ struct cifsd_ipc_msg {
 	unsigned char		____payload[0];
 };
 
-#define CIFSD_IPC_MSG_PAYLOAD(m)	\
-	((void *)(m) + offsetof(struct cifsd_ipc_msg, ____payload))
+#define CIFSD_IPC_MSG_PAYLOAD(m)					\
+	(void *)(((struct cifsd_ipc_msg *)(m))->____payload)
 
 struct ipc_msg_table_entry {
 	unsigned int		handle;


### PR DESCRIPTION
The macro is perfetctly fine, but our static analyzer doesn't like
it:
	Arithmetic operations on /void */ is a GNU C extension, which
	defines the /sizeof(void)/ to be 1.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>