### PR TITLE
cifsd: fix smb2_write NULL pointer dereference

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -1489,6 +1489,7 @@ int smb2_tree_connect(struct cifsd_work *work)
 	char *treename = NULL, *name = NULL;
 	struct cifsd_tree_conn_status status;
 	struct cifsd_share_config *share;
+	int rc = -EINVAL;
 
 	req = (struct smb2_tree_connect_req *)REQUEST_BUF(work);
 	rsp = (struct smb2_tree_connect_rsp *)RESPONSE_BUF(work);
@@ -1552,6 +1553,7 @@ out_err1:
 	switch (status.ret) {
 	case CIFSD_TREE_CONN_STATUS_OK:
 		rsp->hdr.Status = NT_STATUS_OK;
+		rc = 0;
 		break;
 	case CIFSD_TREE_CONN_STATUS_NO_SHARE:
 		rsp->hdr.Status = NT_STATUS_BAD_NETWORK_PATH;
@@ -1573,7 +1575,8 @@ out_err1:
 	default:
 		rsp->hdr.Status = NT_STATUS_ACCESS_DENIED;
 	}
-	return status.ret;
+
+	return rc;
 }
 
 /**


### PR DESCRIPTION
Fix: compound request  tree_conn, write

If we have denied tree_conn, then work->tcon is NULL; but we don't
recheck ->tcon when we process next command in compound request and
end up NULL dereferencing ->tcon. Return a porper negative error
code from tree_connect and abort further compound request processing.

BUG: unable to handle kernel NULL pointer dereference at 0000000000000008
PF error: [normal kernel read fault]
PGD 0 P4D 0
Oops: 0000 [#1] PREEMPT SMP PTI
CPU: 7 PID: 251 Comm: kworker/7:4 Tainted: G        W         4.20.0-rc4-next-20181128-dbg-00005-gd6f00891d986-dirty #3009
Workqueue: events handle_cifsd_work [cifsd]
RIP: 0010:smb2_write+0x10f/0x2f0 [cifsd]
Code: 00 00 00 00 0f c8 83 c0 10 0f c8 41 89 04 24 31 c0 48 83 c4 18 5b 5d 41 5c 41 5d 41 5e 41 5f c3 48 8b 45 38 4d 89 e5 48 89 d3 <48> 8b 40 08 f6 40 11 01 0f 85 2f ff ff ff 48 8b 53 54 48 89 ef 48
RSP: 0018:ffffa2f64082fde0 EFLAGS: 00010246
RAX: 0000000000000000 RBX: ffff89c94c3c4300 RCX: 0000000000000009
RDX: ffff89c94c3c4300 RSI: 0000000000000009 RDI: ffff89c94b0977c0
RBP: ffff89c94b0977c0 R08: 0000000000000001 R09: 0000000000000001
R10: 0000000000000000 R11: 0000000000000000 R12: ffff89c94551da00
R13: ffff89c94551da00 R14: ffffffffc02a81e8 R15: ffff89c94b097828
FS:  0000000000000000(0000) GS:ffff89c94ebc0000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 0000000000000008 CR3: 0000000278012005 CR4: 00000000001606e0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
Call Trace:
 handle_cifsd_work+0x168/0x360 [cifsd]
 process_one_work+0x22e/0x5a0
 worker_thread+0x50/0x3b0
 kthread+0x105/0x140
 ? process_one_work+0x5a0/0x5a0
 ? kthread_create_on_node+0x40/0x40
 ret_from_fork+0x3a/0x50

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>