### PR TITLE
cifsd: rollback to unlock codes for waiting task

### DIFF
--- a/server.c
+++ b/server.c
@@ -159,11 +159,14 @@ andx_again:
 		}
 	}
 
+	mutex_unlock(&conn->srv_mutex);
 	ret = cmds->proc(work);
+	mutex_lock(&conn->srv_mutex);
+
 	if (ret < 0)
 		cifsd_debug("Failed to process %u [%d]\n", command, ret);
 	/* AndX commands - chained request can return positive values */
-	if (ret > 0) {
+	else if (ret > 0) {
 		command = ret;
 		*cmd = command;
 		goto andx_again;


### PR DESCRIPTION
This is a patch to rollback codes.

In case of a notify task that is currently being implemented, it will be
set to asynchronous and wait for any file change events. Therefore, the
locking should be released before cmds->proc(), so that the next commands
from clients can be processed.

int smb2_notify(struct cifsd_work *cifsd_work)
{
    ...

    setup_async_work();
    smb2_send_interim_resp();

    // waiting for notification here
    cifsd_file_notify_wait();
    ...
}

Signed-off-by: Yunjae Lim <yunjae.lim@samsung.com>