### PR TITLE
cifsd: fake success return by changing byte lock range

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -5802,8 +5802,7 @@ int smb2_lock(struct cifsd_work *work)
 			if (lock_length >
 					OFFSET_MAX - flock->fl_start) {
 				cifsd_debug("Invalid lock range requested\n");
-				rsp->hdr.Status = NT_STATUS_INVALID_LOCK_RANGE;
-				goto out;
+				lock_length = OFFSET_MAX - flock->fl_start;
 			}
 		} else
 			lock_length = 0;


### PR DESCRIPTION
linux locking supports byte range up to 2^31, But window allowed lock
range up to 2^63. and cifsd return invalid range range error response with
such request. But this is causing write failure from some application.
They try to write after locking with 2^63 range. cifsd fakes success return
by changing byte lock range.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>