### PR TITLE
cifsd: Fix compilation for v4.9.0 linux kernels

### DIFF
--- a/server.c
+++ b/server.c
@@ -454,7 +454,7 @@ static ssize_t stats_show(struct class *class,
 	return sz;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0)
 static CLASS_ATTR_RO(stats);
 
 static struct attribute *cifsd_control_class_attrs[] = {


### PR DESCRIPTION
It seems that **.class_groups** was not introduced in kernel [v4.9.0](https://elixir.bootlin.com/linux/v4.9/source/include/linux/device.h#L364) but in [v4.10.0](https://elixir.bootlin.com/linux/v4.10/source/include/linux/device.h#L365)

Commit to the kernel that introduced **.class_groups**
https://github.com/torvalds/linux/commit/ced6473e7486702f530a49f886b73195e4977734